### PR TITLE
Add admin verification flows for log reviews

### DIFF
--- a/INTERNS/admin/assignments.php
+++ b/INTERNS/admin/assignments.php
@@ -1,0 +1,124 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors','1'); ini_set('display_startup_errors','1'); error_reporting(E_ALL);
+
+require_once __DIR__ . '/../app/config.php';
+$config = (isset($config) && is_array($config)) ? $config : (is_array(@require __DIR__ . '/../app/config.php') ? require __DIR__ . '/../app/config.php' : []);
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/helpers.php';
+require_role(['admin']);
+
+function app_base(?array $cfg): string {
+  if (defined('APP_BASE')) return rtrim((string)APP_BASE, '/');
+  return rtrim((string)($cfg['APP_BASE'] ?? ''), '/');
+}
+$APP_BASE = app_base($config);
+
+/* CSRF */
+if (!function_exists('csrf_token')) {
+  function csrf_token(): string { $_SESSION['_csrf']=$_SESSION['_csrf']??bin2hex(random_bytes(16)); return $_SESSION['_csrf']; }
+}
+if (!function_exists('csrf_check')) {
+  function csrf_check(): void {
+    $ok = isset($_POST['_csrf'], $_SESSION['_csrf']) && hash_equals($_SESSION['_csrf'], $_POST['_csrf']);
+    if(!$ok){ http_response_code(400); exit('Bad CSRF'); }
+  }
+}
+
+$students = $pdo->query("SELECT id,name,email FROM users WHERE role='student' ORDER BY name")->fetchAll(PDO::FETCH_ASSOC);
+$lects    = $pdo->query("SELECT id,name,email FROM users WHERE role='lecturer' ORDER BY name")->fetchAll(PDO::FETCH_ASSOC);
+$supvs    = $pdo->query("SELECT id,name,email FROM users WHERE role='supervisor' ORDER BY name")->fetchAll(PDO::FETCH_ASSOC);
+
+$msg='';
+if ($_SERVER['REQUEST_METHOD']==='POST') {
+  csrf_check();
+  $student    = (int)($_POST['student'] ?? 0);
+  $lecturer   = (int)($_POST['lecturer'] ?? 0);
+  $supervisor = (int)($_POST['supervisor'] ?? 0);
+  $lecturer   = $lecturer>0 ? $lecturer : null;
+  $supervisor = $supervisor>0 ? $supervisor : null;
+
+  if ($student>0) {
+    $st=$pdo->prepare("INSERT INTO student_assignments (student_user_id,lecturer_user_id,supervisor_user_id)
+                       VALUES (?,?,?)
+                       ON DUPLICATE KEY UPDATE lecturer_user_id=VALUES(lecturer_user_id),
+                                               supervisor_user_id=VALUES(supervisor_user_id)");
+    $st->execute([$student,$lecturer,$supervisor]);
+    $msg='Saved.';
+  }
+}
+
+$rows = $pdo->query("
+  SELECT s.student_user_id,
+         su.name  AS student_name,
+         lu.name  AS lecturer_name,
+         pu.name  AS supervisor_name
+  FROM student_assignments s
+  LEFT JOIN users su ON su.id = s.student_user_id
+  LEFT JOIN users lu ON lu.id = s.lecturer_user_id
+  LEFT JOIN users pu ON pu.id = s.supervisor_user_id
+  ORDER BY su.name
+")->fetchAll(PDO::FETCH_ASSOC);
+
+$title='Admin · Assignments';
+?>
+<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title><?= h($title) ?></title>
+<link rel="stylesheet" href="<?= $APP_BASE ?>/assets/style.css">
+</head><body>
+<?php include __DIR__.'/../app/header.php'; ?>
+<div class="container">
+  <h1>Student Assignments</h1>
+  <?php if($msg): ?><div class="alert success"><?= h($msg) ?></div><?php endif; ?>
+
+  <form method="post" class="form" style="display:grid;gap:.75rem;max-width:640px">
+    <input type="hidden" name="_csrf" value="<?= csrf_token() ?>">
+    <label>Student
+      <select name="student" required>
+        <option value="">-- choose student --</option>
+        <?php foreach($students as $s): ?>
+          <option value="<?= (int)$s['id'] ?>"><?= h($s['name'].' ('.$s['email'].')') ?></option>
+        <?php endforeach; ?>
+      </select>
+    </label>
+    <label>Lecturer
+      <select name="lecturer">
+        <option value="">-- none --</option>
+        <?php foreach($lects as $l): ?>
+          <option value="<?= (int)$l['id'] ?>"><?= h($l['name'].' ('.$l['email'].')') ?></option>
+        <?php endforeach; ?>
+      </select>
+    </label>
+    <label>Supervisor
+      <select name="supervisor">
+        <option value="">-- none --</option>
+        <?php foreach($supvs as $p): ?>
+          <option value="<?= (int)$p['id'] ?>"><?= h($p['name'].' ('.$p['email'].')') ?></option>
+        <?php endforeach; ?>
+      </select>
+    </label>
+    <button class="btn" type="submit">Save</button>
+  </form>
+
+  <h2 class="mt">Current</h2>
+  <div class="table-wrap">
+    <table class="table">
+      <thead><tr><th>Student</th><th>Lecturer</th><th>Supervisor</th></tr></thead>
+      <tbody>
+        <?php foreach($rows as $r): ?>
+          <tr>
+            <td><?= h($r['student_name'] ?? '-') ?></td>
+            <td><?= h($r['lecturer_name'] ?? '-') ?></td>
+            <td><?= h($r['supervisor_name'] ?? '-') ?></td>
+          </tr>
+        <?php endforeach; if(!$rows): ?>
+          <tr><td colspan="3">No assignments yet.</td></tr>
+        <?php endif; ?>
+      </tbody>
+    </table>
+  </div>
+</div>
+</body></html>

--- a/INTERNS/admin/daily_list.php
+++ b/INTERNS/admin/daily_list.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors','1'); ini_set('display_startup_errors','1'); error_reporting(E_ALL);
+
+require_once __DIR__ . '/../app/config.php';
+$config = require __DIR__ . '/../app/config.php';
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/helpers.php';
+require_role(['admin']);
+
+function app_base(?array $cfg): string {
+  return rtrim((string)($cfg['APP_BASE'] ?? ''), '/');
+}
+$APP_BASE = app_base($config);
+
+/* Filters */
+$q    = trim($_GET['q'] ?? '');
+$from = trim($_GET['from'] ?? '');
+$to   = trim($_GET['to'] ?? '');
+
+$where = []; $args=[];
+if ($q   !== '') { $where[]="(u.name LIKE ? OR u.email LIKE ?)"; $args[]="%$q%"; $args[]="%$q%"; }
+if ($from!== '') { $where[]="d.log_date >= ?"; $args[]=$from; }
+if ($to  !== '') { $where[]="d.log_date <= ?"; $args[]=$to; }
+$sqlWhere = $where ? "WHERE ".implode(" AND ", $where) : "";
+
+/* Query */
+$sql = "
+  SELECT d.id, d.log_date, d.activity, d.status,
+         u.name, u.email
+  FROM daily_logs d
+  JOIN users u ON u.id = d.user_id
+  $sqlWhere
+  ORDER BY d.log_date DESC, d.id DESC
+  LIMIT 500
+";
+$st=$pdo->prepare($sql); $st->execute($args); $rows=$st->fetchAll(PDO::FETCH_ASSOC);
+
+/* CSV export */
+if (isset($_GET['export']) && $_GET['export']==='csv') {
+  header('Content-Type: text/csv');
+  header('Content-Disposition: attachment; filename="admin_daily_logs.csv"');
+  $out=fopen('php://output','w');
+  fputcsv($out,['Date','Student','Email','Activity','Status']);
+  foreach($rows as $r){
+    fputcsv($out,[$r['log_date'],$r['name'],$r['email'],$r['activity'],$r['status']]);
+  }
+  exit;
+}
+
+$title="Admin · Daily Logs";
+?>
+<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title><?=h($title)?></title>
+<link rel="stylesheet" href="<?=$APP_BASE?>/assets/style.css">
+</head><body>
+<?php include __DIR__.'/../app/header.php'; ?>
+<div class="container">
+  <h1>All Daily Logs</h1>
+
+  <form method="get" class="filters" style="display:flex;gap:.5rem;flex-wrap:wrap;margin:.75rem 0 1rem">
+    <input name="q" value="<?=h($q)?>" placeholder="Search student">
+    <input type="date" name="from" value="<?=h($from)?>">
+    <input type="date" name="to"   value="<?=h($to)?>">
+    <button class="btn">Filter</button>
+    <button class="btn" name="export" value="csv">Export CSV</button>
+    <button class="btn" type="button" onclick="window.print()">Print</button>
+  </form>
+
+  <table class="table">
+    <thead><tr><th>Date</th><th>Student</th><th>Activity</th><th>Status</th><th>Actions</th></tr></thead>
+    <tbody>
+    <?php foreach($rows as $r): ?>
+      <tr>
+        <td><?=h($r['log_date'])?></td>
+        <td><?=h($r['name'])?> <small>(<?=h($r['email'])?>)</small></td>
+        <td><?=h($r['activity'])?></td>
+        <td><span class="status <?=h(strtolower($r['status']))?>"><?=h($r['status'])?></span></td>
+        <td><a class="btn small" href="<?=$APP_BASE?>/admin/verify_daily.php?id=<?=(int)$r['id']?>">View / Verify</a></td>
+      </tr>
+    <?php endforeach; if(!$rows): ?>
+      <tr><td colspan="5">No results.</td></tr>
+    <?php endif; ?>
+    </tbody>
+  </table>
+</div>
+</body></html>

--- a/INTERNS/admin/dashboard.php
+++ b/INTERNS/admin/dashboard.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__.'/../app/auth.php';  require_role(['admin']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+ini_set('display_errors','1'); error_reporting(E_ALL);
+
+function table_exists(PDO $pdo, string $t): bool {
+  $st = $pdo->prepare("SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ? LIMIT 1");
+  $st->execute([$t]);
+  return (bool)$st->fetchColumn();
+}
+function safe_count(PDO $pdo, string $t): int {
+  if (!table_exists($pdo,$t)) return 0;
+  return (int)$pdo->query("SELECT COUNT(*) FROM `$t`")->fetchColumn();
+}
+
+$counts = [
+  'users'  => safe_count($pdo,'users'),
+  'daily'  => table_exists($pdo,'daily_logs') ? safe_count($pdo,'daily_logs') : safe_count($pdo,'logs'),
+  'weekly' => safe_count($pdo,'weekly_reports'),
+  'leaves' => safe_count($pdo,'leaves'),
+];
+
+include __DIR__.'/../app/header.php';
+?>
+<h2>Admin Dashboard</h2>
+
+<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px">
+  <div style="padding:16px;background:var(--card,#fff);color:var(--text,#0f172a);border:1px solid var(--line,#e5e7eb);border-radius:12px;box-shadow:0 1px 2px rgba(0,0,0,.06)">
+    <span style="color:var(--muted,#475569)">Users:</span> <strong><?= (int)$counts['users'] ?></strong>
+  </div>
+  <div style="padding:16px;background:var(--card,#fff);color:var(--text,#0f172a);border:1px solid var(--line,#e5e7eb);border-radius:12px;box-shadow:0 1px 2px rgba(0,0,0,.06)">
+    <span style="color:var(--muted,#475569)">Daily logs:</span> <strong><?= (int)$counts['daily'] ?></strong>
+  </div>
+  <div style="padding:16px;background:var(--card,#fff);color:var(--text,#0f172a);border:1px solid var(--line,#e5e7eb);border-radius:12px;box-shadow:0 1px 2px rgba(0,0,0,.06)">
+    <span style="color:var(--muted,#475569)">Weekly reports:</span> <strong><?= (int)$counts['weekly'] ?></strong>
+  </div>
+  <div style="padding:16px;background:var(--card,#fff);color:var(--text,#0f172a);border:1px solid var(--line,#e5e7eb);border-radius:12px;box-shadow:0 1px 2px rgba(0,0,0,.06)">
+    <span style="color:var(--muted,#475569)">Leaves:</span> <strong><?= (int)$counts['leaves'] ?></strong>
+  </div>
+</div>
+
+<p style="margin-top:16px">
+  <a class="btn" href="<?= url('/admin/users.php') ?>">Manage Users</a>
+</p>
+
+</main></body></html>

--- a/INTERNS/admin/leaves_list.php
+++ b/INTERNS/admin/leaves_list.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors','1'); ini_set('display_startup_errors','1'); error_reporting(E_ALL);
+
+/*
+ * Tables/columns used:
+ *   leaves(id, user_id, date_from, date_to, reason, status)
+ *   users(id, name, email)
+ */
+
+require_once __DIR__ . '/../app/config.php';
+$config = (isset($config) && is_array($config)) ? $config : (is_array(@require __DIR__ . '/../app/config.php') ? require __DIR__ . '/../app/config.php' : []);
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/helpers.php';
+require_role(['admin']);
+
+function app_base(?array $cfg): string {
+  if (defined('APP_BASE')) return rtrim((string)APP_BASE, '/');
+  return rtrim((string)($cfg['APP_BASE'] ?? ''), '/');
+}
+$APP_BASE = app_base($config);
+
+$q      = trim($_GET['q'] ?? '');
+$from   = trim($_GET['from'] ?? '');
+$to     = trim($_GET['to'] ?? '');
+$status = trim($_GET['status'] ?? '');
+
+$where = []; $args=[];
+if ($q     !== '') { $where[] = "(u.name LIKE ? OR u.email LIKE ?)"; $args[]="%$q%"; $args[]="%$q%"; }
+if ($from  !== '') { $where[] = "l.date_from >= ?"; $args[]=$from; }
+if ($to    !== '') { $where[] = "l.date_to   <= ?"; $args[]=$to; }
+if ($status!== '') { $where[] = "l.status = ?";     $args[]=$status; }
+$sqlWhere = $where ? ('WHERE '.implode(' AND ',$where)) : '';
+
+$sql = "
+  SELECT l.id, l.user_id, l.date_from, l.date_to, l.reason, l.status,
+         u.name, u.email
+  FROM leaves l
+  JOIN users u ON u.id = l.user_id
+  $sqlWhere
+  ORDER BY l.date_from DESC, l.id DESC
+  LIMIT 200
+";
+$st = $pdo->prepare($sql); $st->execute($args); $rows = $st->fetchAll(PDO::FETCH_ASSOC);
+
+$statuses = ['pending','approved','rejected'];
+$title = 'Admin · Leaves';
+?>
+<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title><?= h($title) ?></title>
+<link rel="stylesheet" href="<?= $APP_BASE ?>/assets/style.css">
+</head><body>
+<?php include __DIR__.'/../app/header.php'; ?>
+<div class="container">
+  <h1>Leaves (All Students)</h1>
+
+  <form method="get" class="filters" style="display:flex;gap:.5rem;flex-wrap:wrap;margin:.75rem 0 1rem">
+    <input name="q" value="<?= h($q) ?>" placeholder="Search student (name/email)">
+    <input type="date" name="from" value="<?= h($from) ?>">
+    <input type="date" name="to"   value="<?= h($to) ?>">
+    <select name="status">
+      <option value="">Any status</option>
+      <?php foreach($statuses as $s): ?>
+        <option value="<?= $s ?>" <?= $status===$s?'selected':'' ?>><?= ucfirst($s) ?></option>
+      <?php endforeach; ?>
+    </select>
+    <button class="btn">Filter</button>
+  </form>
+
+  <div class="table-wrap">
+    <table class="table">
+      <thead><tr>
+        <th>Dates</th><th>Student</th><th>Reason</th><th>Status</th><th>Actions</th>
+      </tr></thead>
+      <tbody>
+      <?php foreach($rows as $r): ?>
+        <tr>
+          <td><?= h($r['date_from']) ?> → <?= h($r['date_to']) ?></td>
+          <td><?= h($r['name']) ?> <small>(<?= h($r['email']) ?>)</small></td>
+          <td><?= h(mb_strimwidth((string)($r['reason'] ?? ''), 0, 120, '…')) ?></td>
+          <td><?= h($r['status']) ?></td>
+          <td><a class="btn small" href="<?= $APP_BASE ?>/admin/verify_leaves.php?id=<?= (int)$r['id'] ?>">View / Verify</a></td>
+        </tr>
+      <?php endforeach; if(!$rows): ?>
+        <tr><td colspan="5">No results.</td></tr>
+      <?php endif; ?>
+      </tbody>
+    </table>
+  </div>
+</div>
+</body></html>

--- a/INTERNS/admin/user_form.php
+++ b/INTERNS/admin/user_form.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors','1'); ini_set('display_startup_errors','1'); error_reporting(E_ALL);
+
+require_once __DIR__ . '/../app/config.php';
+$config = (isset($config) && is_array($config)) ? $config : (is_array(@require __DIR__ . '/../app/config.php') ? require __DIR__ . '/../app/config.php' : []);
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/helpers.php';
+require_role(['admin']);
+
+function app_base(?array $cfg): string {
+  if (defined('APP_BASE')) return rtrim((string)APP_BASE, '/');
+  return rtrim((string)($cfg['APP_BASE'] ?? ''), '/');
+}
+$APP_BASE = app_base($config);
+
+/* CSRF */
+if (!function_exists('csrf_token')) {
+  function csrf_token(): string { $_SESSION['_csrf']=$_SESSION['_csrf']??bin2hex(random_bytes(16)); return $_SESSION['_csrf']; }
+}
+if (!function_exists('csrf_check')) {
+  function csrf_check(): void {
+    $ok = isset($_POST['_csrf'], $_SESSION['_csrf']) && hash_equals($_SESSION['_csrf'], $_POST['_csrf']);
+    if(!$ok){ http_response_code(400); exit('Bad CSRF'); }
+  }
+}
+
+$roles = ['student','lecturer','supervisor','admin'];
+$id    = (int)($_GET['id'] ?? 0);
+$edit  = $id > 0;
+
+$name=''; $email=''; $role='student'; $status=1;
+
+if ($edit) {
+  $st=$pdo->prepare("SELECT id,name,email,role,status FROM users WHERE id=?");
+  $st->execute([$id]);
+  $row=$st->fetch(PDO::FETCH_ASSOC);
+  if(!$row){ http_response_code(404); exit('User not found'); }
+  $name=$row['name']; $email=$row['email']; $role=$row['role']; $status=(int)$row['status'];
+}
+
+$err='';
+if ($_SERVER['REQUEST_METHOD']==='POST') {
+  csrf_check();
+  $name  = trim($_POST['name'] ?? '');
+  $email = trim($_POST['email'] ?? '');
+  $role  = in_array($_POST['role'] ?? 'student',$roles,true) ? $_POST['role'] : 'student';
+  $status= isset($_POST['status']) ? 1 : 0;
+  $pwd   = (string)($_POST['password'] ?? '');
+
+  if ($name==='' || $email==='') { $err='Name and Email are required.'; }
+  if (!$err && !filter_var($email, FILTER_VALIDATE_EMAIL)) { $err='Invalid email.'; }
+
+  if (!$err) {
+    if ($edit) {
+      $pdo->prepare("UPDATE users SET name=?, email=?, role=?, status=? WHERE id=?")
+          ->execute([$name,$email,$role,$status,$id]);
+      if ($pwd!=='') {
+        $hash=password_hash($pwd,PASSWORD_DEFAULT);
+        $pdo->prepare("UPDATE users SET password_hash=? WHERE id=?")->execute([$hash,$id]);
+      }
+    } else {
+      if ($pwd==='') { $pwd = bin2hex(random_bytes(4)); } // fallback temp pass
+      $hash=password_hash($pwd,PASSWORD_DEFAULT);
+      $pdo->prepare("INSERT INTO users (name,email,password_hash,role,status,created_at) VALUES (?,?,?,?,?,NOW())")
+          ->execute([$name,$email,$hash,$role,$status]);
+    }
+    header('Location: '.$APP_BASE.'/admin/users.php'); exit;
+  }
+}
+$title = $edit ? 'Edit User' : 'New User';
+?>
+<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title><?= h($title) ?></title>
+<link rel="stylesheet" href="<?= $APP_BASE ?>/assets/style.css">
+</head><body>
+<?php include __DIR__.'/../app/header.php'; ?>
+<div class="container">
+  <h1><?= h($title) ?></h1>
+  <?php if($err): ?><div class="alert danger"><?= h($err) ?></div><?php endif; ?>
+
+  <form method="post" class="form" style="max-width:560px;display:grid;gap:.75rem">
+    <input type="hidden" name="_csrf" value="<?= csrf_token() ?>">
+    <label>Name
+      <input name="name" required value="<?= h($name) ?>">
+    </label>
+    <label>Email
+      <input type="email" name="email" required value="<?= h($email) ?>">
+    </label>
+    <label>Role
+      <select name="role">
+        <?php foreach($roles as $r): ?>
+          <option value="<?= $r ?>" <?= $r===$role?'selected':'' ?>><?= ucfirst($r) ?></option>
+        <?php endforeach; ?>
+      </select>
+    </label>
+    <label><input type="checkbox" name="status" value="1" <?= $status?'checked':''; ?>> Active</label>
+
+    <fieldset class="mt" style="border:1px solid #ddd;padding:.75rem;border-radius:.5rem">
+      <legend><?= $edit?'Set New Password (optional)':'Password' ?></legend>
+      <input type="password" name="password" placeholder="<?= $edit?'Leave blank to keep current':'' ?>">
+    </fieldset>
+
+    <div style="display:flex;gap:.5rem;flex-wrap:wrap">
+      <button class="btn" type="submit">Save</button>
+      <a class="btn secondary" href="<?= $APP_BASE ?>/admin/users.php">Cancel</a>
+    </div>
+  </form>
+</div>
+</body></html>

--- a/INTERNS/admin/users.php
+++ b/INTERNS/admin/users.php
@@ -1,0 +1,161 @@
+<?php
+declare(strict_types=1);
+
+ini_set('display_errors','1');
+ini_set('display_startup_errors','1');
+error_reporting(E_ALL);
+
+require_once __DIR__ . '/../app/config.php';
+$config = (isset($config) && is_array($config)) 
+  ? $config 
+  : (is_array(@require __DIR__ . '/../app/config.php') ? require __DIR__ . '/../app/config.php' : []);
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/helpers.php';
+
+require_role(['admin']);
+
+/* Base URL helper compatible with both styles (constant or array) */
+function app_base(?array $cfg): string {
+  if (defined('APP_BASE')) return rtrim((string)APP_BASE, '/');
+  $b = (string)($cfg['APP_BASE'] ?? '');
+  return rtrim($b, '/');
+}
+$APP_BASE = app_base($config);
+
+/* ===== CSRF ===== */
+if (!function_exists('csrf_token')) {
+  function csrf_token(): string {
+    $_SESSION['_csrf'] = $_SESSION['_csrf'] ?? bin2hex(random_bytes(16));
+    return $_SESSION['_csrf'];
+  }
+}
+if (!function_exists('csrf_check')) {
+  function csrf_check(): void {
+    $ok = isset($_POST['_csrf'], $_SESSION['_csrf']) 
+       && hash_equals($_SESSION['_csrf'], $_POST['_csrf']);
+    if (!$ok) { http_response_code(400); exit('Bad CSRF'); }
+  }
+}
+
+/* ===== Actions: toggle / delete ===== */
+if ($_SERVER['REQUEST_METHOD']==='POST') {
+  csrf_check();
+  $action = $_POST['action'] ?? '';
+  $id = (int)($_POST['id'] ?? 0);
+
+  if ($action==='toggle' && $id>0) {
+    $st=$pdo->prepare("UPDATE users SET status = IF(status=1,0,1) WHERE id=?");
+    $st->execute([$id]);
+    header('Location: '.$_SERVER['REQUEST_URI']); exit;
+  }
+
+  if ($action==='delete' && $id>0) {
+    if ($id === (int)($_SESSION['user']['id'] ?? 0)) {
+      header('Location: '.$_SERVER['REQUEST_URI']); exit; // prevent self-delete
+    }
+    $st=$pdo->prepare("DELETE FROM users WHERE id=?");
+    $st->execute([$id]);
+    header('Location: '.$_SERVER['REQUEST_URI']); exit;
+  }
+}
+
+/* ===== Filters & pagination ===== */
+$roles = ['student','lecturer','supervisor','admin'];
+$q     = trim($_GET['q'] ?? '');
+$role  = trim($_GET['role'] ?? '');
+$page  = max(1, (int)($_GET['page'] ?? 1));
+$per   = 20;
+$off   = ($page-1)*$per;
+
+$where = []; $args=[];
+if ($q!=='') { $where[]="(name LIKE ? OR email LIKE ?)"; $args[]="%$q%"; $args[]="%$q%"; }
+if ($role!=='' && in_array($role,$roles,true)) { $where[]="role=?"; $args[]=$role; }
+$sqlWhere = $where ? ('WHERE '.implode(' AND ', $where)) : '';
+
+/* ===== Count ===== */
+$st = $pdo->prepare("SELECT COUNT(*) FROM users $sqlWhere");
+$st->execute($args);
+$total = (int)$st->fetchColumn();
+
+/* ===== Data ===== */
+$st = $pdo->prepare("SELECT id,name,email,role,status,created_at FROM users $sqlWhere ORDER BY id DESC LIMIT $per OFFSET $off");
+$st->execute($args);
+$rows = $st->fetchAll(PDO::FETCH_ASSOC);
+
+$totalPages = max(1, (int)ceil($total / $per));
+$title = 'Admin · Users';
+?>
+<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title><?= h($title) ?></title>
+<link rel="stylesheet" href="<?= $APP_BASE ?>/assets/style.css">
+</head><body>
+<?php include __DIR__.'/../app/header.php'; ?>
+
+<div class="container">
+  <header class="page-header" style="display:flex;justify-content:space-between;align-items:center;gap:.5rem;margin:.75rem 0 1rem">
+    <h1 style="margin:0">Users</h1>
+    <a class="btn" href="<?= $APP_BASE ?>/admin/user_form.php">New User</a>
+  </header>
+
+  <form method="get" class="filters" style="display:flex;gap:.5rem;flex-wrap:wrap;margin:.5rem 0 1rem">
+    <input name="q" value="<?= h($q) ?>" placeholder="Search name/email">
+    <select name="role">
+      <option value="">All roles</option>
+      <?php foreach($roles as $r): ?>
+        <option value="<?= $r ?>" <?= $r===$role?'selected':'' ?>><?= ucfirst($r) ?></option>
+      <?php endforeach; ?>
+    </select>
+    <button class="btn" type="submit">Filter</button>
+  </form>
+
+  <div class="table-wrap" style="overflow:auto">
+    <table class="table" style="min-width:720px">
+      <thead><tr>
+        <th>ID</th><th>Name</th><th>Email</th><th>Role</th><th>Status</th><th>Created</th><th>Actions</th>
+      </tr></thead>
+      <tbody>
+        <?php foreach($rows as $r): ?>
+          <tr>
+            <td><?= (int)$r['id'] ?></td>
+            <td><?= h($r['name']) ?></td>
+            <td><?= h($r['email']) ?></td>
+            <td><?= h($r['role']) ?></td>
+            <td><?= ((int)$r['status']===1 ? 'Active' : 'Disabled') ?></td>
+            <td><?= h($r['created_at']) ?></td>
+            <td style="display:flex;gap:.25rem;flex-wrap:wrap">
+              <a class="btn small" href="<?= $APP_BASE ?>/admin/user_form.php?id=<?= (int)$r['id'] ?>">Edit</a>
+
+              <form method="post" onsubmit="return confirm('Toggle active/disabled?')">
+                <input type="hidden" name="_csrf" value="<?= csrf_token() ?>">
+                <input type="hidden" name="action" value="toggle">
+                <input type="hidden" name="id" value="<?= (int)$r['id'] ?>">
+                <button class="btn small" type="submit"><?= ((int)$r['status']===1?'Disable':'Enable') ?></button>
+              </form>
+
+              <form method="post" onsubmit="return confirm('Delete this user? This cannot be undone.')">
+                <input type="hidden" name="_csrf" value="<?= csrf_token() ?>">
+                <input type="hidden" name="action" value="delete">
+                <input type="hidden" name="id" value="<?= (int)$r['id'] ?>">
+                <button class="btn small danger" type="submit">Delete</button>
+              </form>
+            </td>
+          </tr>
+        <?php endforeach; ?>
+        <?php if(!$rows): ?>
+          <tr><td colspan="7">No users found.</td></tr>
+        <?php endif; ?>
+      </tbody>
+    </table>
+  </div>
+
+  <nav class="pagination" style="margin-top:1rem;display:flex;gap:.25rem;flex-wrap:wrap">
+    <?php for($i=1;$i<=$totalPages;$i++): 
+      $u = htmlspecialchars($_SERVER['PHP_SELF'].'?'.http_build_query(['q'=>$q,'role'=>$role,'page'=>$i]),ENT_QUOTES,'UTF-8'); ?>
+      <a class="btn small <?= $i===$page?'active':'' ?>" href="<?= $u ?>"><?= $i ?></a>
+    <?php endfor; ?>
+  </nav>
+</div>
+</body></html>

--- a/INTERNS/admin/verify_daily.php
+++ b/INTERNS/admin/verify_daily.php
@@ -1,0 +1,212 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors', '1'); ini_set('display_startup_errors', '1'); error_reporting(E_ALL);
+
+require_once __DIR__ . '/../app/config.php';
+$config = (isset($config) && is_array($config)) ? $config : (is_array(@require __DIR__ . '/../app/config.php') ? require __DIR__ . '/../app/config.php' : []);
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/helpers.php';
+require_role(['admin']);
+
+function table_exists(PDO $pdo, string $table): bool {
+    $st = $pdo->prepare("SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ? LIMIT 1");
+    $st->execute([$table]);
+    return (bool) $st->fetchColumn();
+}
+
+function col_exists(PDO $pdo, string $table, string $col): bool {
+    $st = $pdo->prepare("SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ? LIMIT 1");
+    $st->execute([$table, $col]);
+    return (bool) $st->fetchColumn();
+}
+
+function pick_table(PDO $pdo, array $candidates, string $fallback): string {
+    foreach ($candidates as $name) {
+        if (table_exists($pdo, $name)) {
+            return $name;
+        }
+    }
+    return $fallback;
+}
+
+$dailyTable = pick_table($pdo, ['daily_logs', 'logs'], 'daily_logs');
+$imageTable = pick_table($pdo, ['daily_images', 'log_images'], 'daily_images');
+$dateColumn = col_exists($pdo, $dailyTable, 'log_date')
+    ? 'log_date'
+    : (col_exists($pdo, $dailyTable, 'date') ? 'date' : 'created_at');
+
+$hasStatus   = col_exists($pdo, $dailyTable, 'status');
+$hasComment  = col_exists($pdo, $dailyTable, 'reviewer_comment');
+$hasReviewer = col_exists($pdo, $dailyTable, 'reviewer_id');
+$hasReviewed = col_exists($pdo, $dailyTable, 'reviewed_at');
+$statuses    = ['submitted', 'approved', 'rejected'];
+
+$id = (int)($_GET['id'] ?? ($_POST['id'] ?? 0));
+if ($id <= 0) {
+    header('Location: daily_list.php');
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $status  = $_POST['status'] ?? '';
+    $comment = trim($_POST['comment'] ?? '');
+
+    $sets = [];
+    $vals = [];
+
+    if ($hasStatus && in_array($status, $statuses, true)) {
+        $sets[] = 'status = ?';
+        $vals[] = $status;
+    }
+
+    if ($hasComment) {
+        $sets[] = 'reviewer_comment = ?';
+        $vals[] = $comment;
+    }
+
+    if ($hasReviewer && $sets) {
+        $sets[] = 'reviewer_id = ?';
+        $vals[] = $_SESSION['user']['id'];
+    }
+
+    if ($hasReviewed && $sets) {
+        $sets[] = 'reviewed_at = ?';
+        $vals[] = date('Y-m-d H:i:s');
+    }
+
+    if ($sets) {
+        $vals[] = $id;
+        $sql = "UPDATE `$dailyTable` SET " . implode(',', $sets) . " WHERE id = ?";
+        $pdo->prepare($sql)->execute($vals);
+    }
+
+    header('Location: verify_daily.php?id=' . $id . '&saved=1');
+    exit;
+}
+
+$st = $pdo->prepare("SELECT d.*, u.name AS student_name, u.email FROM `$dailyTable` d JOIN users u ON u.id = d.user_id WHERE d.id = ? LIMIT 1");
+$st->execute([$id]);
+$log = $st->fetch(PDO::FETCH_ASSOC);
+
+$imagePaths = [];
+if ($imageTable && table_exists($pdo, $imageTable)) {
+    $fk = null;
+    if (col_exists($pdo, $imageTable, 'daily_id')) {
+        $fk = 'daily_id';
+    } elseif (col_exists($pdo, $imageTable, 'log_id')) {
+        $fk = 'log_id';
+    }
+
+    if ($fk) {
+        $imgSt = $pdo->prepare("SELECT path FROM `$imageTable` WHERE `$fk` = ? ORDER BY id");
+        $imgSt->execute([$id]);
+        $imagePaths = $imgSt->fetchAll(PDO::FETCH_COLUMN);
+    }
+}
+
+$reviewerName = null;
+if ($hasReviewer && !empty($log['reviewer_id'])) {
+    $who = $pdo->prepare('SELECT name FROM users WHERE id = ?');
+    $who->execute([(int)$log['reviewer_id']]);
+    $reviewerName = $who->fetchColumn() ?: null;
+}
+
+include __DIR__ . '/../app/header.php';
+?>
+<h1>Daily Log Review</h1>
+<p><a class="btn ghost" href="<?= url('/admin/daily_list.php') ?>">← Back to Daily Logs</a></p>
+
+<?php if (!$log): ?>
+  <div class="error">Daily log not found.</div>
+<?php else: ?>
+  <?php if (isset($_GET['saved'])): ?>
+    <div class="ok">Review updated.</div>
+  <?php endif; ?>
+
+  <section class="card" style="margin:1rem 0;padding:1rem;border:1px solid var(--line);border-radius:.75rem;">
+    <h2 style="margin-top:0">Student</h2>
+    <p><strong><?= h($log['student_name'] ?? '') ?></strong><br>
+       <small><?= h($log['email'] ?? '') ?></small></p>
+  </section>
+
+  <section class="card" style="margin:1rem 0;padding:1rem;border:1px solid var(--line);border-radius:.75rem;">
+    <h2 style="margin-top:0">Log Details</h2>
+    <dl class="detail-grid" style="display:grid;grid-template-columns:160px 1fr;gap:.35rem 1rem;">
+      <?php
+        $fieldMap = [
+          $dateColumn        => 'Date',
+          'hari'             => 'Day',
+          'tugas'            => 'Project / Activity',
+          'activity'         => 'Activity',
+          'objektif'         => 'Objective',
+          'peralatan'        => 'Tools / Equipment',
+          'prosedur'         => 'Procedure',
+          'kesimpulan'       => 'Conclusion',
+          'hours'            => 'Hours',
+          'notes'            => 'Notes',
+          'status'           => 'Current Status',
+        ];
+        foreach ($fieldMap as $key => $label):
+          if (!array_key_exists($key, $log) || $log[$key] === null || $log[$key] === '') continue;
+      ?>
+        <dt style="font-weight:600;"><?= h($label) ?></dt>
+        <dd style="margin:0 0 .35rem;white-space:pre-wrap;"><?= nl2br(h((string)$log[$key])) ?></dd>
+      <?php endforeach; ?>
+    </dl>
+
+    <?php if ($imagePaths): ?>
+      <div style="margin-top:1rem;display:flex;flex-wrap:wrap;gap:.5rem;">
+        <?php foreach ($imagePaths as $path): $full = url(strpos($path, '/uploads/') === 0 ? $path : ('/'.ltrim($path,'/'))); ?>
+          <a href="<?= h($full) ?>" target="_blank" rel="noopener">
+            <img src="<?= h($full) ?>" alt="Daily log attachment" style="height:90px;width:120px;object-fit:cover;border-radius:.4rem;box-shadow:0 1px 4px rgba(0,0,0,.12);">
+          </a>
+        <?php endforeach; ?>
+      </div>
+    <?php endif; ?>
+  </section>
+
+  <section class="card" style="margin:1rem 0;padding:1rem;border:1px solid var(--line);border-radius:.75rem;">
+    <h2 style="margin-top:0">Admin Review</h2>
+    <?php if ($reviewerName): ?>
+      <p><strong>Last reviewed by:</strong> <?= h($reviewerName) ?></p>
+    <?php endif; ?>
+    <?php if ($hasReviewed && !empty($log['reviewed_at'])): ?>
+      <p><strong>Reviewed at:</strong> <?= h($log['reviewed_at']) ?></p>
+    <?php endif; ?>
+
+    <?php if ($hasComment && !empty($log['reviewer_comment'])): ?>
+      <p><strong>Existing comment:</strong><br><?= nl2br(h($log['reviewer_comment'])) ?></p>
+    <?php endif; ?>
+
+    <?php if ($hasStatus || $hasComment): ?>
+      <form method="post" class="stack" style="display:grid;gap:.75rem;margin-top:1rem;">
+        <input type="hidden" name="id" value="<?= (int)$id ?>">
+        <?php if ($hasStatus): ?>
+          <label>Status
+            <select name="status" required>
+              <?php foreach ($statuses as $state): ?>
+                <option value="<?= h($state) ?>" <?= ($log['status'] ?? '') === $state ? 'selected' : '' ?>><?= ucfirst($state) ?></option>
+              <?php endforeach; ?>
+            </select>
+          </label>
+        <?php endif; ?>
+
+        <?php if ($hasComment): ?>
+          <label>Comment
+            <textarea name="comment" rows="4" placeholder="Add notes for the student or supervisors."><?= h($log['reviewer_comment'] ?? '') ?></textarea>
+          </label>
+        <?php endif; ?>
+
+        <div style="display:flex;gap:.5rem;flex-wrap:wrap;">
+          <button class="btn">Save review</button>
+          <a class="btn ghost" href="<?= url('/admin/daily_list.php') ?>">Cancel</a>
+        </div>
+      </form>
+    <?php else: ?>
+      <p class="error">This daily log table does not have status/comment columns to update.</p>
+    <?php endif; ?>
+  </section>
+<?php endif; ?>
+
+</main></body></html>

--- a/INTERNS/admin/verify_leaves.php
+++ b/INTERNS/admin/verify_leaves.php
@@ -1,0 +1,230 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors', '1'); ini_set('display_startup_errors', '1'); error_reporting(E_ALL);
+
+require_once __DIR__ . '/../app/config.php';
+$config = (isset($config) && is_array($config)) ? $config : (is_array(@require __DIR__ . '/../app/config.php') ? require __DIR__ . '/../app/config.php' : []);
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/helpers.php';
+require_role(['admin']);
+
+function table_exists(PDO $pdo, string $table): bool {
+    $st = $pdo->prepare("SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ? LIMIT 1");
+    $st->execute([$table]);
+    return (bool)$st->fetchColumn();
+}
+
+function col_exists(PDO $pdo, string $table, string $col): bool {
+    $st = $pdo->prepare("SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ? LIMIT 1");
+    $st->execute([$table, $col]);
+    return (bool)$st->fetchColumn();
+}
+
+function pick_table(PDO $pdo, array $candidates, string $fallback): string {
+    foreach ($candidates as $name) {
+        if (table_exists($pdo, $name)) {
+            return $name;
+        }
+    }
+    return $fallback;
+}
+
+$leaveTable = pick_table($pdo, ['leaves', 'leave_requests'], 'leaves');
+$fileTable  = pick_table($pdo, ['leaves_files', 'leave_files'], 'leaves_files');
+
+$userFk = 'user_id';
+if (!col_exists($pdo, $leaveTable, $userFk) && col_exists($pdo, $leaveTable, 'student_id')) {
+    $userFk = 'student_id';
+}
+
+$hasStatus   = col_exists($pdo, $leaveTable, 'status');
+$hasComment  = col_exists($pdo, $leaveTable, 'reviewer_comment');
+$hasReviewer = col_exists($pdo, $leaveTable, 'reviewer_id');
+$hasReviewed = col_exists($pdo, $leaveTable, 'reviewed_at');
+$statuses    = ['pending', 'approved', 'rejected'];
+
+$id = (int)($_GET['id'] ?? ($_POST['id'] ?? 0));
+if ($id <= 0) {
+    header('Location: leaves_list.php');
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $status  = $_POST['status'] ?? '';
+    $comment = trim($_POST['comment'] ?? '');
+
+    $sets = [];
+    $vals = [];
+
+    if ($hasStatus && in_array($status, $statuses, true)) {
+        $sets[] = 'status = ?';
+        $vals[] = $status;
+    }
+
+    if ($hasComment) {
+        $sets[] = 'reviewer_comment = ?';
+        $vals[] = $comment;
+    }
+
+    if ($hasReviewer && $sets) {
+        $sets[] = 'reviewer_id = ?';
+        $vals[] = $_SESSION['user']['id'];
+    }
+
+    if ($hasReviewed && $sets) {
+        $sets[] = 'reviewed_at = ?';
+        $vals[] = date('Y-m-d H:i:s');
+    }
+
+    if ($sets) {
+        $vals[] = $id;
+        $sql = "UPDATE `$leaveTable` SET " . implode(',', $sets) . " WHERE id = ?";
+        $pdo->prepare($sql)->execute($vals);
+    }
+
+    header('Location: verify_leaves.php?id=' . $id . '&saved=1');
+    exit;
+}
+
+$st = $pdo->prepare("SELECT l.*, u.name AS student_name, u.email FROM `$leaveTable` l JOIN users u ON u.id = l.`$userFk` WHERE l.id = ? LIMIT 1");
+$st->execute([$id]);
+$leave = $st->fetch(PDO::FETCH_ASSOC);
+
+$files = [];
+if ($fileTable && table_exists($pdo, $fileTable)) {
+    $fk = null;
+    if (col_exists($pdo, $fileTable, 'leave_id')) {
+        $fk = 'leave_id';
+    } elseif (col_exists($pdo, $fileTable, 'leaves_id')) {
+        $fk = 'leaves_id';
+    }
+
+    if ($fk) {
+        $fSt = $pdo->prepare("SELECT path, original_name FROM `$fileTable` WHERE `$fk` = ? ORDER BY id");
+        $fSt->execute([$id]);
+        $files = $fSt->fetchAll(PDO::FETCH_ASSOC);
+    }
+}
+
+$reviewerName = null;
+if ($hasReviewer && !empty($leave['reviewer_id'])) {
+    $who = $pdo->prepare('SELECT name FROM users WHERE id = ?');
+    $who->execute([(int)$leave['reviewer_id']]);
+    $reviewerName = $who->fetchColumn() ?: null;
+}
+
+function leave_file_url(string $path): ?string {
+    $clean = str_replace('\\', '/', $path);
+    if (strpos($clean, '/uploads/') !== false) {
+        $pos = strpos($clean, '/uploads/');
+        return substr($clean, $pos);
+    }
+    if (strpos($clean, 'uploads/') === 0) {
+        return '/' . $clean;
+    }
+    if ($clean && $clean[0] === '/') {
+        return $clean;
+    }
+    return null;
+}
+
+include __DIR__ . '/../app/header.php';
+?>
+<h1>Leave Request Review</h1>
+<p><a class="btn ghost" href="<?= url('/admin/leaves_list.php') ?>">← Back to Leaves</a></p>
+
+<?php if (!$leave): ?>
+  <div class="error">Leave request not found.</div>
+<?php else: ?>
+  <?php if (isset($_GET['saved'])): ?>
+    <div class="ok">Review updated.</div>
+  <?php endif; ?>
+
+  <section class="card" style="margin:1rem 0;padding:1rem;border:1px solid var(--line);border-radius:.75rem;">
+    <h2 style="margin-top:0">Student</h2>
+    <p><strong><?= h($leave['student_name'] ?? '') ?></strong><br>
+       <small><?= h($leave['email'] ?? '') ?></small></p>
+  </section>
+
+  <section class="card" style="margin:1rem 0;padding:1rem;border:1px solid var(--line);border-radius:.75rem;">
+    <h2 style="margin-top:0">Leave Details</h2>
+    <dl class="detail-grid" style="display:grid;grid-template-columns:180px 1fr;gap:.35rem 1rem;">
+      <?php
+        $fieldMap = [
+          'date_from'  => 'Start Date',
+          'date_to'    => 'End Date',
+          'leave_date' => 'Leave Date',
+          'days'       => 'Days',
+          'reason'     => 'Reason',
+          'status'     => 'Current Status',
+        ];
+        foreach ($fieldMap as $key => $label):
+          if (!array_key_exists($key, $leave) || $leave[$key] === null || $leave[$key] === '') continue;
+      ?>
+        <dt style="font-weight:600;"><?= h($label) ?></dt>
+        <dd style="margin:0 0 .35rem;white-space:pre-wrap;">
+          <?= nl2br(h((string)$leave[$key])) ?>
+        </dd>
+      <?php endforeach; ?>
+    </dl>
+
+    <?php if ($files): ?>
+      <div style="margin-top:1rem;display:flex;flex-direction:column;gap:.35rem;">
+        <?php foreach ($files as $file): $web = $file['path'] ? leave_file_url($file['path']) : null; ?>
+          <?php if ($web): $href = url($web); ?>
+            <a href="<?= h($href) ?>" target="_blank" rel="noopener" class="btn ghost" style="width:fit-content;">
+              <?= h($file['original_name'] ?: basename($web)) ?>
+            </a>
+          <?php else: ?>
+            <span><?= h($file['original_name'] ?: basename((string)$file['path'])) ?></span>
+          <?php endif; ?>
+        <?php endforeach; ?>
+      </div>
+    <?php endif; ?>
+  </section>
+
+  <section class="card" style="margin:1rem 0;padding:1rem;border:1px solid var(--line);border-radius:.75rem;">
+    <h2 style="margin-top:0">Admin Review</h2>
+    <?php if ($reviewerName): ?>
+      <p><strong>Last reviewed by:</strong> <?= h($reviewerName) ?></p>
+    <?php endif; ?>
+    <?php if ($hasReviewed && !empty($leave['reviewed_at'])): ?>
+      <p><strong>Reviewed at:</strong> <?= h($leave['reviewed_at']) ?></p>
+    <?php endif; ?>
+
+    <?php if ($hasComment && !empty($leave['reviewer_comment'])): ?>
+      <p><strong>Existing comment:</strong><br><?= nl2br(h($leave['reviewer_comment'])) ?></p>
+    <?php endif; ?>
+
+    <?php if ($hasStatus || $hasComment): ?>
+      <form method="post" class="stack" style="display:grid;gap:.75rem;margin-top:1rem;">
+        <input type="hidden" name="id" value="<?= (int)$id ?>">
+        <?php if ($hasStatus): ?>
+          <label>Status
+            <select name="status" required>
+              <?php foreach ($statuses as $state): ?>
+                <option value="<?= h($state) ?>" <?= ($leave['status'] ?? '') === $state ? 'selected' : '' ?>><?= ucfirst($state) ?></option>
+              <?php endforeach; ?>
+            </select>
+          </label>
+        <?php endif; ?>
+
+        <?php if ($hasComment): ?>
+          <label>Comment
+            <textarea name="comment" rows="4" placeholder="Add notes for the student or supervisors."><?= h($leave['reviewer_comment'] ?? '') ?></textarea>
+          </label>
+        <?php endif; ?>
+
+        <div style="display:flex;gap:.5rem;flex-wrap:wrap;">
+          <button class="btn">Save review</button>
+          <a class="btn ghost" href="<?= url('/admin/leaves_list.php') ?>">Cancel</a>
+        </div>
+      </form>
+    <?php else: ?>
+      <p class="error">This leave table does not have status/comment columns to update.</p>
+    <?php endif; ?>
+  </section>
+<?php endif; ?>
+
+</main></body></html>

--- a/INTERNS/admin/verify_weekly.php
+++ b/INTERNS/admin/verify_weekly.php
@@ -1,0 +1,225 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors', '1'); ini_set('display_startup_errors', '1'); error_reporting(E_ALL);
+
+require_once __DIR__ . '/../app/config.php';
+$config = (isset($config) && is_array($config)) ? $config : (is_array(@require __DIR__ . '/../app/config.php') ? require __DIR__ . '/../app/config.php' : []);
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/helpers.php';
+require_role(['admin']);
+
+function table_exists(PDO $pdo, string $table): bool {
+    $st = $pdo->prepare("SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ? LIMIT 1");
+    $st->execute([$table]);
+    return (bool)$st->fetchColumn();
+}
+
+function col_exists(PDO $pdo, string $table, string $col): bool {
+    $st = $pdo->prepare("SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ? LIMIT 1");
+    $st->execute([$table, $col]);
+    return (bool)$st->fetchColumn();
+}
+
+function pick_table(PDO $pdo, array $candidates, string $fallback): string {
+    foreach ($candidates as $name) {
+        if (table_exists($pdo, $name)) {
+            return $name;
+        }
+    }
+    return $fallback;
+}
+
+$weeklyTable = pick_table($pdo, ['weekly_reports', 'weekly_report', 'weekly_logs', 'weekly'], 'weekly_reports');
+$imageTable  = pick_table($pdo, ['weekly_images', 'weekly_photos'], 'weekly_images');
+
+$userFk = 'user_id';
+if (!col_exists($pdo, $weeklyTable, $userFk) && col_exists($pdo, $weeklyTable, 'student_id')) {
+    $userFk = 'student_id';
+}
+
+$hasStatus   = col_exists($pdo, $weeklyTable, 'status');
+$hasComment  = col_exists($pdo, $weeklyTable, 'reviewer_comment');
+$hasReviewer = col_exists($pdo, $weeklyTable, 'reviewer_id');
+$hasReviewed = col_exists($pdo, $weeklyTable, 'reviewed_at');
+$statuses    = ['submitted', 'approved', 'rejected'];
+
+$id = (int)($_GET['id'] ?? ($_POST['id'] ?? 0));
+if ($id <= 0) {
+    header('Location: weekly_list.php');
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $status  = $_POST['status'] ?? '';
+    $comment = trim($_POST['comment'] ?? '');
+
+    $sets = [];
+    $vals = [];
+
+    if ($hasStatus && in_array($status, $statuses, true)) {
+        $sets[] = 'status = ?';
+        $vals[] = $status;
+    }
+
+    if ($hasComment) {
+        $sets[] = 'reviewer_comment = ?';
+        $vals[] = $comment;
+    }
+
+    if ($hasReviewer && $sets) {
+        $sets[] = 'reviewer_id = ?';
+        $vals[] = $_SESSION['user']['id'];
+    }
+
+    if ($hasReviewed && $sets) {
+        $sets[] = 'reviewed_at = ?';
+        $vals[] = date('Y-m-d H:i:s');
+    }
+
+    if ($sets) {
+        $vals[] = $id;
+        $sql = "UPDATE `$weeklyTable` SET " . implode(',', $sets) . " WHERE id = ?";
+        $pdo->prepare($sql)->execute($vals);
+    }
+
+    header('Location: verify_weekly.php?id=' . $id . '&saved=1');
+    exit;
+}
+
+$st = $pdo->prepare("SELECT w.*, u.name AS student_name, u.email FROM `$weeklyTable` w JOIN users u ON u.id = w.`$userFk` WHERE w.id = ? LIMIT 1");
+$st->execute([$id]);
+$report = $st->fetch(PDO::FETCH_ASSOC);
+
+$imagePaths = [];
+if ($imageTable && table_exists($pdo, $imageTable)) {
+    $fk = null;
+    if (col_exists($pdo, $imageTable, 'weekly_id')) {
+        $fk = 'weekly_id';
+    } elseif (col_exists($pdo, $imageTable, 'weekly_report_id')) {
+        $fk = 'weekly_report_id';
+    } elseif (col_exists($pdo, $imageTable, 'report_id')) {
+        $fk = 'report_id';
+    }
+
+    if ($fk) {
+        $imgSt = $pdo->prepare("SELECT path FROM `$imageTable` WHERE `$fk` = ? ORDER BY id");
+        $imgSt->execute([$id]);
+        $imagePaths = $imgSt->fetchAll(PDO::FETCH_COLUMN);
+    }
+}
+
+$reviewerName = null;
+if ($hasReviewer && !empty($report['reviewer_id'])) {
+    $who = $pdo->prepare('SELECT name FROM users WHERE id = ?');
+    $who->execute([(int)$report['reviewer_id']]);
+    $reviewerName = $who->fetchColumn() ?: null;
+}
+
+include __DIR__ . '/../app/header.php';
+?>
+<h1>Weekly Report Review</h1>
+<p><a class="btn ghost" href="<?= url('/admin/weekly_list.php') ?>">← Back to Weekly Reports</a></p>
+
+<?php if (!$report): ?>
+  <div class="error">Weekly report not found.</div>
+<?php else: ?>
+  <?php if (isset($_GET['saved'])): ?>
+    <div class="ok">Review updated.</div>
+  <?php endif; ?>
+
+  <section class="card" style="margin:1rem 0;padding:1rem;border:1px solid var(--line);border-radius:.75rem;">
+    <h2 style="margin-top:0">Student</h2>
+    <p><strong><?= h($report['student_name'] ?? '') ?></strong><br>
+       <small><?= h($report['email'] ?? '') ?></small></p>
+  </section>
+
+  <section class="card" style="margin:1rem 0;padding:1rem;border:1px solid var(--line);border-radius:.75rem;">
+    <h2 style="margin-top:0">Report Details</h2>
+    <dl class="detail-grid" style="display:grid;grid-template-columns:180px 1fr;gap:.35rem 1rem;">
+      <?php
+        $fieldMap = [
+          'week_start'         => 'Week Start',
+          'week_end'           => 'Week End',
+          'report_date'        => 'Report Date',
+          'week_no'            => 'Week Number',
+          'week'               => 'Week',
+          'activities_summary' => 'Activities Summary',
+          'activity_summary'   => 'Activity Summary',
+          'highlights'         => 'Highlights',
+          'skills_gained'      => 'Skills Gained',
+          'knowledge'          => 'Knowledge Gained',
+          'impact_on_student'  => 'Impact',
+          'impact'             => 'Impact',
+          'challenges'         => 'Challenges',
+          'supervisor_comment' => 'Supervisor Comment',
+          'status'             => 'Current Status',
+        ];
+        $seen = [];
+        foreach ($fieldMap as $key => $label):
+          if (isset($seen[$label])) continue; // avoid duplicates when both summary fields exist
+          if (!array_key_exists($key, $report) || $report[$key] === null || $report[$key] === '') continue;
+          $seen[$label] = true;
+      ?>
+        <dt style="font-weight:600;"><?= h($label) ?></dt>
+        <dd style="margin:0 0 .35rem;white-space:pre-wrap;">
+          <?= nl2br(h((string)$report[$key])) ?>
+        </dd>
+      <?php endforeach; ?>
+    </dl>
+
+    <?php if ($imagePaths): ?>
+      <div style="margin-top:1rem;display:flex;flex-wrap:wrap;gap:.5rem;">
+        <?php foreach ($imagePaths as $path): $full = url(strpos($path, '/uploads/') === 0 ? $path : ('/'.ltrim($path,'/'))); ?>
+          <a href="<?= h($full) ?>" target="_blank" rel="noopener">
+            <img src="<?= h($full) ?>" alt="Weekly report attachment" style="height:100px;width:140px;object-fit:cover;border-radius:.4rem;box-shadow:0 1px 4px rgba(0,0,0,.12);">
+          </a>
+        <?php endforeach; ?>
+      </div>
+    <?php endif; ?>
+  </section>
+
+  <section class="card" style="margin:1rem 0;padding:1rem;border:1px solid var(--line);border-radius:.75rem;">
+    <h2 style="margin-top:0">Admin Review</h2>
+    <?php if ($reviewerName): ?>
+      <p><strong>Last reviewed by:</strong> <?= h($reviewerName) ?></p>
+    <?php endif; ?>
+    <?php if ($hasReviewed && !empty($report['reviewed_at'])): ?>
+      <p><strong>Reviewed at:</strong> <?= h($report['reviewed_at']) ?></p>
+    <?php endif; ?>
+
+    <?php if ($hasComment && !empty($report['reviewer_comment'])): ?>
+      <p><strong>Existing comment:</strong><br><?= nl2br(h($report['reviewer_comment'])) ?></p>
+    <?php endif; ?>
+
+    <?php if ($hasStatus || $hasComment): ?>
+      <form method="post" class="stack" style="display:grid;gap:.75rem;margin-top:1rem;">
+        <input type="hidden" name="id" value="<?= (int)$id ?>">
+        <?php if ($hasStatus): ?>
+          <label>Status
+            <select name="status" required>
+              <?php foreach ($statuses as $state): ?>
+                <option value="<?= h($state) ?>" <?= ($report['status'] ?? '') === $state ? 'selected' : '' ?>><?= ucfirst($state) ?></option>
+              <?php endforeach; ?>
+            </select>
+          </label>
+        <?php endif; ?>
+
+        <?php if ($hasComment): ?>
+          <label>Comment
+            <textarea name="comment" rows="4" placeholder="Add notes for the student or supervisors."><?= h($report['reviewer_comment'] ?? '') ?></textarea>
+          </label>
+        <?php endif; ?>
+
+        <div style="display:flex;gap:.5rem;flex-wrap:wrap;">
+          <button class="btn">Save review</button>
+          <a class="btn ghost" href="<?= url('/admin/weekly_list.php') ?>">Cancel</a>
+        </div>
+      </form>
+    <?php else: ?>
+      <p class="error">This weekly report table does not have status/comment columns to update.</p>
+    <?php endif; ?>
+  </section>
+<?php endif; ?>
+
+</main></body></html>

--- a/INTERNS/admin/weekly_list.php
+++ b/INTERNS/admin/weekly_list.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors','1'); ini_set('display_startup_errors','1'); error_reporting(E_ALL);
+
+/*
+ * Tables/columns used (from your screenshot):
+ *   weekly_reports(
+ *     id, user_id,
+ *     week_start DATE, week_no INT,
+ *     activities_summary TEXT, activity_summary TEXT, highlights TEXT,
+ *     report_date DATE, created_at TIMESTAMP,
+ *     status ENUM('submitted','approved','rejected','signed'),
+ *     ...
+ *   )
+ *   users(id, name, email)
+ */
+
+require_once __DIR__ . '/../app/config.php';
+$config = (isset($config) && is_array($config)) ? $config : (is_array(@require __DIR__ . '/../app/config.php') ? require __DIR__ . '/../app/config.php' : []);
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/helpers.php';
+
+require_role(['admin']);
+
+function app_base(?array $cfg): string {
+  if (defined('APP_BASE')) return rtrim((string)APP_BASE, '/');
+  return rtrim((string)($cfg['APP_BASE'] ?? ''), '/');
+}
+$APP_BASE = app_base($config);
+
+/* --------- Filters --------- */
+$q    = trim($_GET['q'] ?? '');
+$from = trim($_GET['from'] ?? '');
+$to   = trim($_GET['to'] ?? '');
+
+$where = []; $args = [];
+
+if ($q !== '') {
+  $where[] = "(u.name LIKE ? OR u.email LIKE ?)";
+  $args[] = "%$q%"; $args[] = "%$q%";
+}
+
+/* Use COALESCE(week_start, report_date, created_at) for date filtering */
+$dateExpr = "COALESCE(w.week_start, w.report_date, w.created_at)";
+if ($from !== '') { $where[] = "$dateExpr >= ?"; $args[] = $from; }
+if ($to   !== '') { $where[] = "$dateExpr <= ?"; $args[] = $to; }
+
+$sqlWhere = $where ? ('WHERE ' . implode(' AND ', $where)) : '';
+
+/* --------- Query --------- */
+$sql = "
+  SELECT
+    w.id,
+    w.user_id,
+    w.week_no,
+    w.week_start,
+    w.report_date,
+    w.created_at,
+    w.status,
+    /* pick first non-null summary-ish field */
+    COALESCE(w.activities_summary, w.activity_summary, w.highlights, '') AS summary,
+    /* computed display date */
+    COALESCE(w.week_start, w.report_date, w.created_at) AS week_val,
+    u.name,
+    u.email
+  FROM weekly_reports w
+  JOIN users u ON u.id = w.user_id
+  $sqlWhere
+  ORDER BY $dateExpr DESC, w.id DESC
+  LIMIT 200
+";
+$st = $pdo->prepare($sql);
+$st->execute($args);
+$rows = $st->fetchAll(PDO::FETCH_ASSOC);
+
+$title = 'Admin · Weekly Reports';
+?>
+<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title><?= h($title) ?></title>
+<link rel="stylesheet" href="<?= $APP_BASE ?>/assets/style.css">
+</head><body>
+<?php include __DIR__.'/../app/header.php'; ?>
+<div class="container">
+  <h1>Weekly Reports (All Students)</h1>
+
+  <form method="get" class="filters" style="display:flex;gap:.5rem;flex-wrap:wrap;margin:.75rem 0 1rem">
+    <input name="q" value="<?= h($q) ?>" placeholder="Search student (name/email)">
+    <input type="date" name="from" value="<?= h($from) ?>">
+    <input type="date" name="to"   value="<?= h($to) ?>">
+    <button class="btn">Filter</button>
+  </form>
+
+  <div class="table-wrap">
+    <table class="table">
+      <thead><tr>
+        <th>Week</th><th>Student</th><th>Summary</th><th>Status</th><th>Actions</th>
+      </tr></thead>
+      <tbody>
+      <?php foreach ($rows as $r): ?>
+        <tr>
+          <td>
+            <?= h((string)$r['week_val']) ?>
+            <?php if ($r['week_no'] !== null): ?>
+              <small>(Week <?= (int)$r['week_no'] ?>)</small>
+            <?php endif; ?>
+          </td>
+          <td><?= h($r['name']) ?> <small>(<?= h($r['email']) ?>)</small></td>
+          <td><?= h(mb_strimwidth((string)$r['summary'], 0, 120, '…')) ?></td>
+          <td><?= h($r['status']) ?></td>
+          <td><a class="btn small" href="<?= $APP_BASE ?>/admin/verify_weekly.php?id=<?= (int)$r['id'] ?>">View / Verify</a></td>
+        </tr>
+      <?php endforeach; if (!$rows): ?>
+        <tr><td colspan="5">No results.</td></tr>
+      <?php endif; ?>
+      </tbody>
+    </table>
+  </div>
+</div>
+</body></html>

--- a/INTERNS/app/auth.php
+++ b/INTERNS/app/auth.php
@@ -1,0 +1,20 @@
+<?php
+require_once __DIR__.'/session.php';
+require_once __DIR__.'/db.php';
+
+function require_login() {
+  if (empty($_SESSION['user'])) {
+    $base = (require __DIR__.'/config.php')['APP_BASE'];
+    header("Location: {$base}/auth/login.php");
+    exit;
+  }
+}
+function require_role(array $roles) {
+  require_login();
+  $role = $_SESSION['user']['role'] ?? '';
+  if (!in_array($role, $roles, true)) {
+    http_response_code(403);
+    echo "Forbidden";
+    exit;
+  }
+}

--- a/INTERNS/app/config.php
+++ b/INTERNS/app/config.php
@@ -1,0 +1,9 @@
+<?php
+return [
+  'APP_BASE' => '/INTERNS', // change if you use a different folder
+  'DB_HOST' => '127.0.0.1',
+  'DB_NAME' => 'interns_app',
+  'DB_USER' => 'root',
+  'DB_PASS' => '',
+  'DEBUG'   => true,
+];

--- a/INTERNS/app/db-test.php
+++ b/INTERNS/app/db-test.php
@@ -1,0 +1,10 @@
+<?php
+$config = require __DIR__.'/config.php';
+$dsn = "mysql:host={$config['DB_HOST']};dbname={$config['DB_NAME']};charset=utf8mb4";
+try {
+  $pdo = new PDO($dsn, $config['DB_USER'], $config['DB_PASS'], [PDO::ATTR_ERRMODE=>PDO::ERRMODE_EXCEPTION]);
+  echo "DB OK on DSN: $dsn";
+} catch (Throwable $e) {
+  header('Content-Type: text/plain; charset=utf-8', true, 500);
+  echo "DB FAIL: ".$e->getMessage()."\nDSN: $dsn\n";
+}

--- a/INTERNS/app/db.php
+++ b/INTERNS/app/db.php
@@ -1,0 +1,15 @@
+<?php
+$config = require __DIR__.'/config.php';
+$dsn = "mysql:host={$config['DB_HOST']};dbname={$config['DB_NAME']};charset=utf8mb4";
+$options = [
+  PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+  PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+];
+try {
+  $pdo = new PDO($dsn, $config['DB_USER'], $config['DB_PASS'], $options);
+} catch (Throwable $e) {
+  http_response_code(500);
+  header('Content-Type: text/plain; charset=utf-8');
+  echo "DB CONNECTION FAILED\n".$e->getMessage()."\n\nDSN: {$dsn}\nUSER: {$config['DB_USER']}\n";
+  exit;
+}

--- a/INTERNS/app/header.php
+++ b/INTERNS/app/header.php
@@ -1,0 +1,117 @@
+<?php
+require_once __DIR__ . '/session.php';
+
+$cfg   = require __DIR__ . '/config.php';
+$base  = $cfg['APP_BASE'];
+$user  = $_SESSION['user'] ?? null;
+$role  = $user['role'] ?? '';
+$public = !empty($PUBLIC_PAGE); // set to true in login/register
+
+// current path (for "active" link)
+$path = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';
+
+if (!function_exists('ends_with')) {
+  function ends_with(string $haystack, string $needle): bool {
+    return $needle === '' || substr($haystack, -strlen($needle)) === $needle;
+  }
+}
+function nav_item(string $base, string $href, string $label, string $path, string $match): string {
+  $url   = htmlspecialchars(rtrim($base, '/') . $href, ENT_QUOTES);
+  $label = htmlspecialchars($label, ENT_QUOTES);
+  $active = ends_with($path, $match) ? ' class="active"' : '';
+  $aria   = $active ? ' aria-current="page"' : '';
+  return "<li{$active}><a href=\"{$url}\"{$aria}>{$label}</a></li>";
+}
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="stylesheet" href="<?= $base ?>/assets/style.css">
+  <script defer src="<?= $base ?>/assets/app.js"></script>
+  <title>INTERNS</title>
+</head>
+<body>
+<header class="topbar">
+  <?php if (!$public): ?>
+    <button id="hamburger" aria-label="menu">☰</button>
+  <?php endif; ?>
+
+  <a href="<?= $base ?>/" class="logo-wrap" aria-label="Home">
+    <img src="<?= $base ?>/assets/logo.svg" class="logo-img" alt="INTERNS logo">
+  </a>
+
+  <strong class="brand">INTERNS</strong>
+  <div class="spacer"></div>
+
+  <button id="theme-toggle" class="icon-btn" aria-label="Toggle theme" title="Toggle theme">🌞</button>
+
+  <?php if ($user && !$public): ?>
+    <span class="who"><?= htmlspecialchars($user['name']) ?> (<?= htmlspecialchars($user['role']) ?>)</span>
+    <a class="btn" href="<?= $base ?>/auth/logout.php">Logout</a>
+  <?php elseif (!$user && !$public): ?>
+    <a class="btn" href="<?= $base ?>/auth/login.php">Login</a>
+  <?php endif; ?>
+</header>
+
+<?php if (!$public): ?>
+<aside id="sidebar" class="sidebar hidden" aria-label="Sidebar">
+  <nav>
+    <ul>
+      <?php if ($user): ?>
+        <?= nav_item($base, '/profile.php', 'Profile', $path, '/profile.php') ?>
+
+        <?php if ($role === 'student'): ?>
+          <?= nav_item($base, '/student/dashboard.php', 'Student Dashboard', $path, '/student/dashboard.php') ?>
+          <?= nav_item($base, '/student/daily_new.php', 'New Daily Log', $path, '/student/daily_new.php') ?>
+          <?= nav_item($base, '/student/daily_list.php', 'My Daily Logs', $path, '/student/daily_list.php') ?>
+          <?= nav_item($base, '/student/weekly_new.php', 'New Weekly Report', $path, '/student/weekly_new.php') ?>
+          <?= nav_item($base, '/student/weekly_list.php', 'My Weekly Reports', $path, '/student/weekly_list.php') ?>
+          <?= nav_item($base, '/student/leave_new.php', 'Request Leave', $path, '/student/leave_new.php') ?>
+          <?= nav_item($base, '/student/leave_list.php', 'My Leave Requests', $path, '/student/leave_list.php') ?>
+
+        <?php elseif ($role === 'lecturer'): ?>
+          <?= nav_item($base, '/lecturer/dashboard.php', 'Lecturer Dashboard', $path, '/lecturer/dashboard.php') ?>
+
+          <!-- New: lists -->
+          <?= nav_item($base, '/lecturer/daily_list.php',  'My Daily Logs',       $path, '/lecturer/daily_list.php') ?>
+          <?= nav_item($base, '/lecturer/weekly_list.php', 'My Weekly Reports',   $path, '/lecturer/weekly_list.php') ?>
+          <?= nav_item($base, '/lecturer/leaves_list.php', 'My Students’ Leaves', $path, '/lecturer/leaves_list.php') ?>
+
+          <hr>
+          <!-- Existing verify pages -->
+          <?= nav_item($base, '/lecturer/verify_daily.php',  'Verify Daily Logs',       $path, '/lecturer/verify_daily.php') ?>
+          <?= nav_item($base, '/lecturer/verify_weekly.php', 'Verify Weekly Reflections',$path, '/lecturer/verify_weekly.php') ?>
+          <?= nav_item($base, '/lecturer/verify_leaves.php', 'Verify Leave Requests',   $path, '/lecturer/verify_leaves.php') ?>
+
+        <?php elseif ($role === 'supervisor'): ?>
+          <?= nav_item($base, '/supervisor/dashboard.php', 'Supervisor Dashboard', $path, '/supervisor/dashboard.php') ?>
+
+          <!-- New: lists -->
+          <?= nav_item($base, '/supervisor/daily_list.php',  'My Daily Logs',       $path, '/supervisor/daily_list.php') ?>
+          <?= nav_item($base, '/supervisor/weekly_list.php', 'My Weekly Reports',   $path, '/supervisor/weekly_list.php') ?>
+          <?= nav_item($base, '/supervisor/leaves_list.php', 'My Students’ Leaves', $path, '/supervisor/leaves_list.php') ?>
+
+          <hr>
+          <!-- Existing verify pages -->
+          <?= nav_item($base, '/supervisor/verify_daily.php',  'Verify Daily Logs',        $path, '/supervisor/verify_daily.php') ?>
+          <?= nav_item($base, '/supervisor/verify_weekly.php', 'Verify Weekly Reflections',$path, '/supervisor/verify_weekly.php') ?>
+          <?= nav_item($base, '/supervisor/verify_leaves.php', 'Verify Leave Requests',    $path, '/supervisor/verify_leaves.php') ?>
+
+        <?php elseif ($role === 'admin'): ?>
+          <?= nav_item($base, '/admin/dashboard.php', 'Admin Dashboard', $path, '/admin/dashboard.php') ?>
+          <?= nav_item($base, '/admin/users.php', 'Manage Users', $path, '/admin/users.php') ?>
+          <?= nav_item($base, '/admin/user_form.php', 'New User', $path, '/admin/user_form.php') ?>
+          <?= nav_item($base, '/admin/assignments.php', 'Assignments', $path, '/admin/assignments.php') ?>
+          <hr>
+          <?= nav_item($base, '/admin/daily_list.php',  'All Daily Logs',     $path, '/admin/daily_list.php') ?>
+          <?= nav_item($base, '/admin/weekly_list.php', 'All Weekly Reports', $path, '/admin/weekly_list.php') ?>
+          <?= nav_item($base, '/admin/leaves_list.php', 'All Leaves',         $path, '/admin/leaves_list.php') ?>
+        <?php endif; ?>
+      <?php endif; ?>
+    </ul>
+  </nav>
+</aside>
+<?php endif; ?>
+
+<main class="container">

--- a/INTERNS/app/helpers.php
+++ b/INTERNS/app/helpers.php
@@ -1,0 +1,3 @@
+<?php
+function h($s){return htmlspecialchars((string)$s,ENT_QUOTES,'UTF-8');}
+function url($path){$base=(require __DIR__.'/config.php')['APP_BASE'];return $base.$path;}

--- a/INTERNS/app/session.php
+++ b/INTERNS/app/session.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+/* Start session early and safely */
+if (session_status() !== PHP_SESSION_ACTIVE) {
+  session_start();
+}
+
+/* Find APP_BASE no matter how config is structured */
+if (!function_exists('session_app_base')) {
+  function session_app_base(): string {
+    // If a constant APP_BASE exists, use it
+    if (defined('APP_BASE')) {
+      return rtrim((string)APP_BASE, '/');
+    }
+    // If a $config array exists in global scope, use it
+    if (isset($GLOBALS['config']) && is_array($GLOBALS['config']) && isset($GLOBALS['config']['APP_BASE'])) {
+      return rtrim((string)$GLOBALS['config']['APP_BASE'], '/');
+    }
+    // Last resort: assume project root folder name (adjust if your app is not in /INTERNS)
+    return '/INTERNS';
+  }
+}
+
+/* Optional tiny debug switch: set to true to see session info on every page (local only) */
+$SESSION_DEBUG = false;  // change to true temporarily if you need
+
+/* -----------------------------------------------
+   Auth helpers
+   ----------------------------------------------- */
+
+if (!function_exists('require_login')) {
+  function require_login(): void {
+    $base = session_app_base();
+
+    // Already logged in?
+    if (!empty($_SESSION['user']) && isset($_SESSION['user']['id'])) {
+      return;
+    }
+
+    // Not logged in → send to login with ?next=
+    $here = $_SERVER['REQUEST_URI'] ?? ($base . '/');
+    // Prevent header issues if output started accidental
+    if (!headers_sent()) {
+      header('Location: ' . $base . '/auth/login.php?next=' . urlencode($here));
+    } else {
+      echo '<meta http-equiv="refresh" content="0;url=' . htmlspecialchars($base . '/auth/login.php?next=' . urlencode($here), ENT_QUOTES, 'UTF-8') . '">';
+    }
+    exit;
+  }
+}
+
+if (!function_exists('require_role')) {
+  /**
+   * Restrict page to specific roles.
+   * Usage: require_role(['admin']); or require_role(['student','admin']);
+   */
+  function require_role(array $roles): void {
+    require_login(); // ensure logged in first
+
+    $role = (string)($_SESSION['user']['role'] ?? '');
+    if (in_array($role, $roles, true)) {
+      return; // allowed
+    }
+
+    // Logged in but not allowed → show a proper 403 page (no blank screen)
+    http_response_code(403);
+    $base = session_app_base();
+    ?>
+    <!doctype html>
+    <html lang="en"><head>
+      <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+      <title>403 · Access denied</title>
+      <link rel="stylesheet" href="<?= htmlspecialchars($base, ENT_QUOTES, 'UTF-8') ?>/assets/style.css">
+      <style>body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;padding:2rem}</style>
+    </head><body>
+      <h1>Access denied</h1>
+      <p>Your role <code><?= htmlspecialchars($role, ENT_QUOTES, 'UTF-8') ?></code> is not permitted to view this page.</p>
+      <p><a class="btn" href="<?= htmlspecialchars($base, ENT_QUOTES, 'UTF-8') ?>/">Go home</a></p>
+    </body></html>
+    <?php
+    exit;
+  }
+}
+
+/* -----------------------------------------------
+   Optional: a tiny session debug banner (local)
+   ----------------------------------------------- */
+if ($SESSION_DEBUG && php_sapi_name() !== 'cli') {
+  $u = $_SESSION['user'] ?? null;
+  $who = $u ? ('#'.($u['id']??'?').' · '.($u['role']??'?').' · '.($u['email']??'?')) : 'guest';
+  echo '<div style="position:fixed;z-index:9999;left:8px;bottom:8px;padding:6px 10px;border-radius:8px;background:#111;color:#fff;opacity:.85;font:12px/1.2 system-ui">';
+  echo 'SESSION: ' . htmlspecialchars($who, ENT_QUOTES, 'UTF-8');
+  echo '</div>';
+}

--- a/INTERNS/assets/app.js
+++ b/INTERNS/assets/app.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // Sidebar
+  const btn = document.getElementById('hamburger');
+  const sb  = document.getElementById('sidebar');
+  if (btn && sb) btn.addEventListener('click', () => sb.classList.toggle('hidden'));
+
+  // Theme
+  const root = document.documentElement; // <html>
+  const toggle = document.getElementById('theme-toggle');
+
+  const apply = (t) => {
+    root.setAttribute('data-theme', t);
+    if (toggle) {
+      // Show the opposite icon (sun when dark, moon when light)
+      toggle.textContent = (t === 'dark') ? '🌞' : '🌙';
+      toggle.setAttribute('aria-label', `Switch to ${(t === 'dark') ? 'light' : 'dark'} mode`);
+      toggle.title = toggle.getAttribute('aria-label');
+    }
+  };
+
+  // Initial: saved pref or system pref, default dark
+  const saved = localStorage.getItem('theme');
+  let start = saved || (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+  apply(start);
+
+  if (toggle) {
+    toggle.addEventListener('click', () => {
+      const next = (root.getAttribute('data-theme') === 'light') ? 'dark' : 'light';
+      apply(next);
+      localStorage.setItem('theme', next);
+    });
+  }
+});

--- a/INTERNS/assets/logo.svg
+++ b/INTERNS/assets/logo.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+    <stop offset="0" stop-color="#21c6c6"></stop><stop offset="1" stop-color="#03a9a9"></stop>
+  </linearGradient></defs>
+  <circle cx="16" cy="16" r="14" fill="url(#g)"></circle>
+  <path d="M16 7l3 6 6 3-6 3-3 6-3-6-6-3 6-3z" fill="#fff" fill-opacity=".95"></path>
+</svg>

--- a/INTERNS/assets/style.css
+++ b/INTERNS/assets/style.css
@@ -1,0 +1,140 @@
+/* ===== THEME TOKENS ===== */
+:root{
+  /* Dark (default) */
+  --bg:#101418;
+  --fg:#e8f0f2;
+  --muted:#9fb3c8;
+  --card:#161b22;
+  --line:#22343f;
+  --input:#0f1318;
+  --accent:#2dd4bf;
+}
+:root[data-theme="light"]{
+  --bg:#f6f7fb;
+  --fg:#0f172a;
+  --muted:#475569;
+  --card:#ffffff;
+  --line:#e5e7eb;
+  --input:#ffffff;
+  --accent:#0ea5e9;
+}
+
+/* ===== BASE ===== */
+*{box-sizing:border-box;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,'Helvetica Neue',Arial}
+html,body{height:100%}
+body{margin:0;background:var(--bg);color:var(--fg)}
+a{color:var(--accent);text-decoration:none}
+.btn{padding:.5rem .8rem;background:var(--accent);color:#042;display:inline-block;border-radius:.5rem;border:0;cursor:pointer}
+.who{margin:0 .5rem}
+
+/* ===== TOPBAR & SIDEBAR ===== */
+.topbar{display:flex;align-items:center;gap:.75rem;background:var(--card);padding:.6rem 1rem;position:sticky;top:0;border-bottom:1px solid var(--line);z-index:10}
+.topbar .spacer{flex:1}
+.logo{font-size:1.2rem}
+.icon-btn{background:transparent;border:0;color:var(--fg);font-size:1.15rem;cursor:pointer;padding:.25rem .4rem;border-radius:.4rem}
+.icon-btn:hover{background:rgba(127,127,127,.12)}
+
+.sidebar{position:fixed;top:3.2rem;left:0;width:240px;background:var(--card);height:calc(100% - 3.2rem);padding:1rem;overflow:auto;border-right:1px solid var(--line)}
+.sidebar.hidden{display:none}
+.sidebar a{display:block;padding:.45rem 0;border-bottom:1px solid var(--line);color:var(--fg)}
+
+/* ===== CONTENT ===== */
+.container{max-width:1000px;margin:1rem auto;padding:0 1rem}
+h2{margin:.2rem 0 1rem}
+form label{display:block;margin:.6rem 0}
+input,select,textarea{width:100%;padding:.5rem;border-radius:.4rem;border:1px solid var(--line);background:var(--input);color:var(--fg)}
+.tbl{width:100%;border-collapse:collapse}
+.tbl th,.tbl td{border-bottom:1px solid var(--line);padding:.55rem;text-align:left;vertical-align:top}
+.ok{color:#38e28d}.error{color:#ff6b6b}
+
+/* Small screens */
+@media (max-width: 768px){
+  .sidebar{width:80%;max-width:320px}
+}
+.logo-wrap{display:flex;align-items:center}
+.logo-img{height:22px; width:auto; display:block} /* tweak height to fit your header */
+/* Theme tokens (if you don't already have them) */
+:root{
+  --bg:#f6f7fb;           /* page background (light) */
+  --text:#0f172a;         /* main text (light) */
+  --line:#e5e7eb;         /* borders (light) */
+  --card:#ffffff;         /* card bg (light) */
+  --muted:#475569;        /* secondary text (light) */
+}
+[data-theme="dark"]{
+  --bg:#0b1220;
+  --text:#e5e7eb;
+  --line:#1f2937;
+  --card:#111827;
+  --muted:#9ca3af;
+}
+
+/* Admin dashboard KPI cards */
+.dashboard-grid{ display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:14px; }
+
+.stat-card, .kpi, .metric {                 /* use whatever class your cards have */
+  background: var(--card) !important;
+  color: var(--text) !important;
+  border: 1px solid var(--line) !important;
+  border-radius: 12px;
+  padding: 16px 18px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.06);
+  /* kill any glass/blur styles leaking in */
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+  background-image: none !important;
+}
+
+/* text inside the card should inherit the corrected color */
+.stat-card *, .kpi *, .metric * { color: inherit !important; }
+.stat-card .muted, .kpi .muted, .metric .muted { color: var(--muted) !important; }
+
+/* Keep sidebar links stacked and allow pushing bottom items */
+.sidebar { height: 100vh; }
+.sidebar .navlist {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+.sidebar .navlist .grow { flex: 1 1 auto; }
+
+.sidebar .profile-item {
+  border-top: 1px solid var(--line, #e5e7eb);
+  padding-top: 8px;
+  margin-top: 8px;        /* optional, just for a little separation */
+}
+
+/* Optional active styling */
+.sidebar li.active > a {
+  background: var(--card, #e5eef9);
+  border-radius: 8px;
+}
+[data-theme="dark"] .sidebar li.active > a {
+  background: #172036;
+}
+/* status badges */
+.status {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.8rem;
+  border-radius: 0.6rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+.status.submitted { background: #f0ad4e; color: #fff; }  /* orange */
+.status.approved  { background: #5cb85c; color: #fff; }  /* green */
+.status.rejected  { background: #d9534f; color: #fff; }  /* red */
+.status.signed    { background: #0275d8; color: #fff; }  /* blue */
+
+/* --- Print-friendly view --- */
+@media print {
+  .topbar, #sidebar, .filters, .btn, .icon-btn, hr { display: none !important; }
+  .container, main.container, .table-wrap, table.table { width: 100% !important; margin: 0 !important; }
+  a[href]:after { content: ""; } /* don’t show URLs after links */
+  body { background: #fff !important; color: #000 !important; }
+  table.table th, table.table td { border-color: #888 !important; }
+}

--- a/INTERNS/auth/forgot.php
+++ b/INTERNS/auth/forgot.php
@@ -1,0 +1,114 @@
+<?php
+declare(strict_types=1);
+
+ini_set('display_errors','1');
+ini_set('display_startup_errors','1');
+ini_set('log_errors','1');
+error_reporting(E_ALL);
+
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/helpers.php';
+
+if (!function_exists('h')) {
+  function h(?string $s): string { return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }
+}
+
+// Create table (safe if it already exists)
+$pdo->exec("CREATE TABLE IF NOT EXISTS password_resets (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  token_hash CHAR(64) NOT NULL,
+  expires_at DATETIME NOT NULL,
+  used TINYINT(1) NOT NULL DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  INDEX token_hash_idx (token_hash),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB");
+
+$sent = false;
+$msg  = '';
+$errors = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $email = trim($_POST['email'] ?? '');
+  if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    $errors['email'] = 'Enter a valid email.';
+  } else {
+    $st = $pdo->prepare("SELECT id, name, email FROM users WHERE email=? LIMIT 1");
+    $st->execute([$email]);
+    $user = $st->fetch(PDO::FETCH_ASSOC);
+
+    // Always act the same even if no user found (don’t reveal existence)
+    if ($user) {
+      $userId = (int)$user['id'];
+      $raw = bin2hex(random_bytes(32)); // 64 hex chars
+      $hash = hash('sha256', $raw);
+      $expires = (new DateTimeImmutable('+30 minutes'))->format('Y-m-d H:i:s');
+
+      $pdo->prepare("INSERT INTO password_resets (user_id, token_hash, expires_at) VALUES (?,?,?)")
+          ->execute([$userId, $hash, $expires]);
+
+      // Build reset URL
+      $resetUrl = url('/auth/reset.php?t=' . urlencode($raw));
+
+      // Try to send email; if mail() not configured, show the link as fallback (dev mode)
+      $subject = 'Password reset';
+      $body = "Hi {$user['name']},\n\nUse this link to reset your password (valid for 30 minutes):\n{$resetUrl}\n\nIf you did not request this, you can ignore this email.";
+      $mailed = @mail($user['email'], $subject, $body, "From: no-reply@localhost");
+
+      if ($mailed) {
+        $msg = 'If that email exists, a reset link has been sent.';
+      } else {
+        // Developer-friendly fallback
+        $msg = 'If that email exists, a reset link is shown below (mail() not configured on this machine).';
+        $devLink = $resetUrl;
+      }
+    } else {
+      $msg = 'If that email exists, a reset link has been sent.';
+    }
+    $sent = true;
+  }
+}
+?>
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Forgot Password · INTERNS</title>
+  <link rel="stylesheet" href="<?= url('/assets/style.css') ?>">
+</head>
+<body class="auth">
+  <main class="container">
+    <div class="auth-card" style="background:var(--card);padding:1rem;border:1px solid var(--line);border-radius:.75rem;max-width:560px;margin:2rem auto">
+      <h1 style="margin-top:0">Forgot password</h1>
+
+      <?php if ($sent): ?>
+        <div class="ok" style="margin-bottom:.75rem"><?= h($msg) ?></div>
+        <?php if (!empty($devLink)): ?>
+          <div class="card" style="background:var(--card);border:1px solid var(--line);padding:.75rem;border-radius:.5rem">
+            <strong>Developer reset link:</strong><br>
+            <a href="<?= h($devLink) ?>"><?= h($devLink) ?></a>
+            <div style="font-size:.85rem;color:var(--muted);margin-top:.5rem">This is displayed because <code>mail()</code> is not configured locally.</div>
+          </div>
+        <?php endif; ?>
+        <p style="margin-top:1rem"><a href="<?= url('/auth/login.php') ?>">Back to login</a></p>
+      <?php else: ?>
+        <?php if ($errors): ?>
+          <div class="error-list" style="margin-bottom:.75rem">
+            <?php foreach ($errors as $e): ?><div class="error"><?= h($e) ?></div><?php endforeach; ?>
+          </div>
+        <?php endif; ?>
+
+        <form method="post">
+          <label>Email
+            <input type="email" name="email" value="<?= h($_POST['email'] ?? '') ?>" required>
+          </label>
+          <button class="btn">Send reset link</button>
+          <p style="margin-top:10px"><a href="<?= url('/auth/login.php') ?>">Back to login</a></p>
+        </form>
+      <?php endif; ?>
+    </div>
+  </main>
+</body>
+</html>

--- a/INTERNS/auth/login.php
+++ b/INTERNS/auth/login.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+ini_set('display_errors','1');
+ini_set('display_startup_errors','1');
+ini_set('log_errors','1');
+error_reporting(E_ALL);
+
+$PUBLIC_PAGE = true;
+
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/helpers.php';
+
+if (!function_exists('h')) {
+  function h(?string $s): string { return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }
+}
+
+$errors = [];
+$email  = '';
+
+// figure out which password column is present
+$uCols  = $pdo->query("SHOW COLUMNS FROM `users`")->fetchAll(PDO::FETCH_COLUMN);
+$uCols  = array_map('strtolower', $uCols);
+$pwdCol = in_array('password_hash', $uCols, true) ? 'password_hash'
+        : (in_array('password', $uCols, true) ? 'password' : null);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $email    = trim($_POST['email'] ?? '');
+  $password = (string)($_POST['password'] ?? '');
+
+  if (!filter_var($email, FILTER_VALIDATE_EMAIL)) $errors['email'] = 'Enter a valid email.';
+  if ($password === '') $errors['password'] = 'Password is required.';
+  if (!$pwdCol) $errors['login'] = 'Password column not found on users table.';
+
+  if (!$errors) {
+    $st = $pdo->prepare("SELECT * FROM users WHERE email=? LIMIT 1");
+    $st->execute([$email]);
+    $user = $st->fetch(PDO::FETCH_ASSOC) ?: null;
+
+    $storedHash = $user[$pwdCol] ?? null;
+
+    if (!$user || !$storedHash || !password_verify($password, (string)$storedHash)) {
+      $errors['login'] = 'Incorrect email or password.';
+    } else {
+      // robust "active" detection for numeric or text status
+      $active = true;
+      if (array_key_exists('status', $user)) {
+        $raw = $user['status'];
+        if (is_numeric($raw)) {
+          $active = ((int)$raw === 1);               // 1 = active
+        } else {
+          $v = strtolower(trim((string)$raw));
+          $active = ($v === '' || $v === 'active' || $v === '1' || $v === 'enabled' || $v === 'approved' || $v === 'true');
+        }
+      }
+
+      if (!$active) {
+        $errors['login'] = 'Your account is not active.';
+      } else {
+        $_SESSION['user'] = [
+          'id'    => (int)$user['id'],
+          'name'  => (string)($user['name'] ?? ''),
+          'email' => (string)($user['email'] ?? ''),
+          'role'  => strtolower((string)($user['role'] ?? ''))
+        ];
+        $role = $_SESSION['user']['role'];
+        $to = '/';
+        if     ($role === 'student'    && file_exists(__DIR__.'/../student/dashboard.php'))    $to = '/student/dashboard.php';
+        elseif ($role === 'lecturer'   && file_exists(__DIR__.'/../lecturer/dashboard.php'))   $to = '/lecturer/dashboard.php';
+        elseif ($role === 'supervisor' && file_exists(__DIR__.'/../supervisor/dashboard.php')) $to = '/supervisor/dashboard.php';
+        elseif ($role === 'admin'      && file_exists(__DIR__.'/../admin/dashboard.php'))      $to = '/admin/dashboard.php';
+        elseif (file_exists(__DIR__.'/../index.php'))                                          $to = '/index.php';
+        header('Location: '.url($to)); exit;
+      }
+    }
+  }
+}
+?>
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Login · INTERNS</title>
+  <link rel="stylesheet" href="<?= url('/assets/style.css') ?>">
+</head>
+<body class="auth">
+  <main class="container">
+    <div class="auth-card" style="background:var(--card);padding:1rem;border:1px solid var(--line);border-radius:.75rem;max-width:560px;margin:2rem auto">
+      <h1 style="margin-top:0">Login</h1>
+
+      <?php if ($errors): ?>
+        <div class="error-list" style="margin-bottom:.75rem">
+          <?php foreach ($errors as $e): ?><div class="error"><?= h($e) ?></div><?php endforeach; ?>
+        </div>
+      <?php endif; ?>
+
+      <form method="post" novalidate>
+        <label>Email
+          <input type="email" name="email" value="<?= h($email) ?>" required>
+        </label>
+        <label>Password
+          <input type="password" name="password" required>
+        </label>
+
+        <div style="display:flex;justify-content:space-between;align-items:center;margin:.25rem 0 .75rem">
+          <a href="<?= url('/auth/forgot.php') ?>">Forgot password?</a>
+        </div>
+
+        <button class="btn">Login</button>
+        <p style="margin-top:10px">No account? <a href="<?= url('/auth/register.php') ?>">Register</a></p>
+      </form>
+    </div>
+  </main>
+</body>
+</html>

--- a/INTERNS/auth/logout.php
+++ b/INTERNS/auth/logout.php
@@ -1,0 +1,5 @@
+<?php
+require_once __DIR__.'/../app/session.php';
+$config = require __DIR__.'/../app/config.php';
+$_SESSION=[]; session_destroy();
+header("Location: {$config['APP_BASE']}/auth/login.php");

--- a/INTERNS/auth/register.php
+++ b/INTERNS/auth/register.php
@@ -1,0 +1,178 @@
+<?php
+declare(strict_types=1);
+
+ini_set('display_errors','1');
+ini_set('display_startup_errors','1');
+ini_set('log_errors','1');
+error_reporting(E_ALL);
+$__errlog = __DIR__ . '/../app/php_errors.log';
+ini_set('error_log', $__errlog);
+
+$PUBLIC_PAGE = true;
+
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/helpers.php';
+
+if (!function_exists('h')) {
+  function h(?string $s): string { return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }
+}
+
+$errors = [];
+$ok = false;
+$roles = ['student','lecturer','supervisor'];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $name        = trim($_POST['name'] ?? '');
+  $email       = trim($_POST['email'] ?? '');
+  $password    = (string)($_POST['password'] ?? '');
+  $role        = strtolower(trim($_POST['role'] ?? 'student'));
+  $matrikStaff = trim($_POST['matrik_staff'] ?? '');
+
+  $start_date = $role === 'student' ? trim($_POST['start_date'] ?? '') : '';
+  $end_date   = $role === 'student' ? trim($_POST['end_date']   ?? '') : '';
+
+  if ($name === '') $errors['name'] = 'Name is required.';
+  if (!filter_var($email, FILTER_VALIDATE_EMAIL)) $errors['email'] = 'Valid email is required.';
+  if (strlen($password) < 6) $errors['password'] = 'Password must be at least 6 characters.';
+  if (!in_array($role, $roles, true)) $errors['role'] = 'Invalid role selected.';
+
+  if (!$errors) {
+    $st = $pdo->prepare("SELECT id FROM users WHERE email=? LIMIT 1");
+    $st->execute([$email]);
+    if ($st->fetch()) $errors['email'] = 'Email already registered.';
+  }
+
+  if (!$errors) {
+    $hash = password_hash($password, PASSWORD_DEFAULT);
+
+    // columns present
+    $cols = $pdo->query("SHOW COLUMNS FROM `users`")->fetchAll(PDO::FETCH_ASSOC);
+    $colNames = array_map(fn($r) => strtolower($r['Field']), $cols);
+
+    // decide status value by column type
+    $statusVal = null;
+    if (in_array('status', $colNames, true)) {
+      $row = array_values(array_filter($cols, fn($r)=>strtolower($r['Field'])==='status'))[0] ?? null;
+      $type = strtolower((string)($row['Type'] ?? ''));
+      $statusVal = (preg_match('/int|decimal|bit|bool/', $type)) ? 1 : 'active';
+    }
+
+    // password column name
+    $pwdCol = in_array('password_hash', $colNames, true) ? 'password_hash'
+            : (in_array('password', $colNames, true) ? 'password' : null);
+
+    $payload = [
+      'name'  => $name,
+      'email' => $email,
+      'role'  => $role,
+    ];
+    if ($pwdCol)  $payload[$pwdCol] = $hash;
+    if ($statusVal !== null) $payload['status'] = $statusVal;
+
+    $insertCols = [];
+    $place = [];
+    $values = [];
+    foreach ($payload as $k => $v) {
+      if (in_array(strtolower($k), $colNames, true)) {
+        $insertCols[] = "`$k`";
+        $place[] = '?';
+        $values[] = $v;
+      }
+    }
+
+    $sql = "INSERT INTO `users` (".implode(',', $insertCols).") VALUES (".implode(',', $place).")";
+    $pdo->prepare($sql)->execute($values);
+
+    if ($role === 'student') {
+      $uid = (int)$pdo->lastInsertId();
+      $tCheck = $pdo->prepare("SELECT 1 FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name='students' LIMIT 1");
+      $tCheck->execute();
+      if ($tCheck->fetchColumn()) {
+        $sCols = $pdo->query("SHOW COLUMNS FROM `students`")->fetchAll(PDO::FETCH_COLUMN);
+        $sCols = array_map('strtolower', $sCols);
+
+        $studentPayload = ['user_id' => $uid];
+        if (in_array('matric_no', $sCols, true))  $studentPayload['matric_no']  = $matrikStaff ?: null;
+        if (in_array('start_date', $sCols, true)) $studentPayload['start_date'] = $start_date ?: null;
+        if (in_array('end_date',   $sCols, true)) $studentPayload['end_date']   = $end_date   ?: null;
+
+        $c = implode(',', array_map(fn($k) => "`$k`", array_keys($studentPayload)));
+        $q = implode(',', array_fill(0, count($studentPayload), '?'));
+        $pdo->prepare("INSERT INTO `students` ($c) VALUES ($q)")->execute(array_values($studentPayload));
+      }
+    }
+
+    $ok = true;
+  }
+}
+?>
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Register · INTERNS</title>
+  <link rel="stylesheet" href="<?= url('/assets/style.css') ?>">
+</head>
+<body class="auth">
+  <main class="container">
+    <div class="auth-card" style="background:var(--card);padding:1rem;border:1px solid var(--line);border-radius:.75rem;max-width:560px;margin:2rem auto">
+      <h1 style="margin-top:0">Create Account</h1>
+
+      <?php if ($ok): ?>
+        <div class="ok">Registration successful. <a href="<?= url('/auth/login.php') ?>">Login</a></div>
+      <?php endif; ?>
+
+      <?php if ($errors && !$ok): ?>
+        <div class="error-list">
+          <?php foreach ($errors as $e): ?><div class="error"><?= h($e) ?></div><?php endforeach; ?>
+        </div>
+      <?php endif; ?>
+
+      <form method="post">
+        <label>Name
+          <input type="text" name="name" value="<?= h($_POST['name'] ?? '') ?>" required>
+        </label>
+        <label>Email
+          <input type="email" name="email" value="<?= h($_POST['email'] ?? '') ?>" required>
+        </label>
+        <label>Password
+          <input type="password" name="password" required>
+        </label>
+
+        <label>Role
+          <select name="role" id="role-select" onchange="toggleStudentDates()" required>
+            <option value="student"   <?= (($_POST['role'] ?? '')==='student'   ? 'selected' : '') ?>>Student</option>
+            <option value="lecturer"  <?= (($_POST['role'] ?? '')==='lecturer'  ? 'selected' : '') ?>>Lecturer</option>
+            <option value="supervisor"<?= (($_POST['role'] ?? '')==='supervisor'? 'selected' : '') ?>>Supervisor</option>
+          </select>
+        </label>
+
+        <label>Matric/Staff No.
+          <input type="text" name="matrik_staff" value="<?= h($_POST['matrik_staff'] ?? '') ?>">
+        </label>
+
+        <div id="student-dates" style="display:none">
+          <label>Start Date
+            <input type="date" name="start_date" value="<?= h($_POST['start_date'] ?? '') ?>">
+          </label>
+          <label>End Date
+            <input type="date" name="end_date" value="<?= h($_POST['end_date'] ?? '') ?>">
+          </label>
+        </div>
+
+        <button class="btn">Register</button>
+        <p style="margin-top:10px">Already have an account? <a href="<?= url('/auth/login.php') ?>">Login</a></p>
+      </form>
+    </div>
+  </main>
+
+<script>
+function toggleStudentDates() {
+  const role = document.getElementById('role-select').value;
+  document.getElementById('student-dates').style.display = (role === 'student') ? '' : 'none';
+}
+toggleStudentDates();
+</script>
+</body>
+</html>

--- a/INTERNS/auth/register_diag.php
+++ b/INTERNS/auth/register_diag.php
@@ -1,0 +1,28 @@
+<?php
+ini_set('display_errors',1);
+ini_set('display_startup_errors',1);
+ini_set('log_errors',1);
+error_reporting(E_ALL);
+
+// also log fatals here:
+$__errlog = __DIR__ . '/../app/php_errors.log';
+ini_set('error_log', $__errlog);
+register_shutdown_function(function () use ($__errlog) {
+  $e = error_get_last();
+  if ($e && in_array($e['type'], [E_ERROR,E_PARSE,E_CORE_ERROR,E_COMPILE_ERROR])) {
+    if (!headers_sent()) header('Content-Type: text/plain; charset=utf-8', true, 500);
+    echo "FATAL: {$e['message']} in {$e['file']}:{$e['line']}\nLog: {$__errlog}\n";
+  }
+});
+
+echo "STEP 1\n";
+require_once __DIR__ . '/../app/session.php';
+echo "STEP 2 session OK\n";
+
+require_once __DIR__ . '/../app/db.php';
+echo "STEP 3 db OK\n";
+
+require_once __DIR__ . '/../app/helpers.php';
+echo "STEP 4 helpers OK\n";
+
+echo "DONE\n";

--- a/INTERNS/auth/reset.php
+++ b/INTERNS/auth/reset.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+ini_set('display_errors','1');
+ini_set('display_startup_errors','1');
+ini_set('log_errors','1');
+error_reporting(E_ALL);
+
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/helpers.php';
+
+if (!function_exists('h')) {
+  function h(?string $s): string { return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }
+}
+
+$token = (string)($_GET['t'] ?? '');
+$valid = false; $error = ''; $done = false;
+$user = null;
+
+if ($token !== '' && ctype_xdigit($token) && strlen($token) === 64) {
+  $hash = hash('sha256', $token);
+
+  // Find matching, unused, unexpired reset record
+  $st = $pdo->prepare("SELECT pr.id, pr.user_id, u.email, u.name
+                       FROM password_resets pr
+                       JOIN users u ON u.id = pr.user_id
+                       WHERE pr.token_hash = ? AND pr.used = 0 AND pr.expires_at > NOW()
+                       ORDER BY pr.id DESC LIMIT 1");
+  $st->execute([$hash]);
+  $row = $st->fetch(PDO::FETCH_ASSOC);
+  if ($row) { $valid = true; $user = $row; }
+} else {
+  $error = 'Invalid or malformed token.';
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $valid) {
+  $p1 = (string)($_POST['password'] ?? '');
+  $p2 = (string)($_POST['password2'] ?? '');
+  if (strlen($p1) < 6) { $error = 'Password must be at least 6 characters.'; }
+  elseif ($p1 !== $p2) { $error = 'Passwords do not match.'; }
+  else {
+    $hashPwd = password_hash($p1, PASSWORD_DEFAULT);
+    $pdo->prepare("UPDATE users SET password=? WHERE id=?")->execute([$hashPwd, (int)$user['user_id']]);
+    // Mark this reset token as used (one-time)
+    $pdo->prepare("UPDATE password_resets SET used=1 WHERE id=?")->execute([(int)$user['id']]);
+    $done = true;
+  }
+}
+?>
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Reset Password · INTERNS</title>
+  <link rel="stylesheet" href="<?= url('/assets/style.css') ?>">
+</head>
+<body class="auth">
+  <main class="container">
+    <div class="auth-card" style="background:var(--card);padding:1rem;border:1px solid var(--line);border-radius:.75rem;max-width:560px;margin:2rem auto">
+      <h1 style="margin-top:0">Reset password</h1>
+
+      <?php if ($done): ?>
+        <div class="ok">Password updated. You can now <a href="<?= url('/auth/login.php') ?>">log in</a>.</div>
+      <?php elseif (!$valid): ?>
+        <div class="error"><?= h($error ?: 'Invalid or expired token.') ?></div>
+        <p style="margin-top:10px"><a href="<?= url('/auth/forgot.php') ?>">Request a new link</a></p>
+      <?php else: ?>
+        <?php if ($error): ?><div class="error" style="margin-bottom:.75rem"><?= h($error) ?></div><?php endif; ?>
+        <form method="post">
+          <label>New password
+            <input type="password" name="password" required>
+          </label>
+          <label>Confirm new password
+            <input type="password" name="password2" required>
+          </label>
+          <button class="btn">Update password</button>
+        </form>
+      <?php endif; ?>
+    </div>
+  </main>
+</body>
+</html>

--- a/INTERNS/index.php
+++ b/INTERNS/index.php
@@ -1,0 +1,15 @@
+<?php
+require_once __DIR__.'/app/session.php';
+$config = require __DIR__.'/app/config.php';
+if(!empty($_SESSION['user'])){
+  $r=$_SESSION['user']['role'];
+  $to = [
+    'student'=>"/student/dashboard.php",
+    'lecturer'=>"/lecturer/dashboard.php",
+    'supervisor'=>"/supervisor/dashboard.php",
+    'admin'=>"/admin/dashboard.php",
+  ][$r] ?? '/auth/login.php';
+  header("Location: {$config['APP_BASE']}{$to}");
+} else {
+  header("Location: {$config['APP_BASE']}/auth/login.php");
+}

--- a/INTERNS/interns.sql
+++ b/INTERNS/interns.sql
@@ -1,0 +1,79 @@
+-- interns.sql - self-contained schema + seed
+-- Engine: MySQL 5.7+/MariaDB 10+
+SET NAMES utf8mb4;
+SET time_zone = '+00:00';
+SET FOREIGN_KEY_CHECKS = 0;
+
+CREATE DATABASE IF NOT EXISTS interns_app CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE interns_app;
+
+-- Users table (admins, students, company reps)
+CREATE TABLE IF NOT EXISTS users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(120) NOT NULL,
+  email VARCHAR(190) NOT NULL UNIQUE,
+  password_hash VARCHAR(255) NOT NULL,
+  role ENUM('admin','student','supervisor','lecturer') NOT NULL DEFAULT 'student',
+  status TINYINT(1) NOT NULL DEFAULT 1,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+-- Companies
+CREATE TABLE IF NOT EXISTS companies (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(200) NOT NULL,
+  address TEXT,
+  contact_person VARCHAR(120),
+  contact_email VARCHAR(190),
+  contact_phone VARCHAR(50),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+-- Courses
+CREATE TABLE IF NOT EXISTS courses (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  code VARCHAR(50) NOT NULL UNIQUE,
+  title VARCHAR(200) NOT NULL,
+  department VARCHAR(100),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+-- Students
+CREATE TABLE IF NOT EXISTS students (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  matric_no VARCHAR(50) NOT NULL UNIQUE,
+  course_id INT,
+  company_id INT,
+  start_date DATE,
+  end_date DATE,
+  supervisor_name VARCHAR(120),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (course_id) REFERENCES courses(id) ON DELETE SET NULL,
+  FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE SET NULL
+) ENGINE=InnoDB;
+
+-- System settings
+CREATE TABLE IF NOT EXISTS system_settings (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL UNIQUE,
+  value TEXT,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+-- Seed minimal data
+INSERT IGNORE INTO system_settings (name, value) VALUES
+('name','Internship Timesheet System'),
+('allow_self_register','0');
+
+-- Admin user (email: admin@example.com, password: Admin@123)
+INSERT IGNORE INTO users (id, name, email, password_hash, role) VALUES
+(1, 'System Admin', 'admin@example.com', '$2y$10$8jV4E.0o2fC3WJmXHSuO4e8mQx5H5lGm9uHkJt4H4eQv7wC1r7WWS', 'admin');
+
+-- Sample course
+INSERT IGNORE INTO courses (code, title, department) VALUES
+('DFP40182','Software Requirement and Design','IT'),
+('DFP40203','Python Programming','IT'),
+('DFP40263','Secure Mobile Computing','IT');
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/INTERNS/lecturer/daily_list.php
+++ b/INTERNS/lecturer/daily_list.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors','1'); ini_set('display_startup_errors','1'); error_reporting(E_ALL);
+
+require_once __DIR__ . '/../app/config.php';
+$config = (isset($config) && is_array($config)) ? $config : (is_array(@require __DIR__ . '/../app/config.php') ? require __DIR__ . '/../app/config.php' : []);
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/helpers.php';
+require_role(['lecturer']);
+
+$me = (int)($_SESSION['user']['id'] ?? 0);
+
+function app_base(?array $cfg): string { return rtrim(defined('APP_BASE') ? (string)APP_BASE : (string)($cfg['APP_BASE']??''), '/'); }
+$APP_BASE = app_base($config);
+
+/* detect student_assignments column names */
+function sa_cols(PDO $pdo): array {
+  $have = function(array $cols) use ($pdo): bool {
+    $in=implode(',',array_fill(0,count($cols),'?'));
+    $st=$pdo->prepare("SELECT COUNT(*) FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name='student_assignments' AND column_name IN ($in)");
+    $st->execute($cols); return (int)$st->fetchColumn()===count($cols);
+  };
+  if ($have(['student_user_id','lecturer_user_id'])) return ['student'=>'student_user_id','reviewer'=>'lecturer_user_id'];
+  if ($have(['student_id','lecturer_id']))           return ['student'=>'student_id','reviewer'=>'lecturer_id'];
+  // best effort fallbacks
+  return ['student'=>'student_user_id','reviewer'=>'lecturer_user_id'];
+}
+$sa = sa_cols($pdo);
+
+/* filters */
+$q    = trim($_GET['q'] ?? '');
+$from = trim($_GET['from'] ?? '');
+$to   = trim($_GET['to'] ?? '');
+
+$where = ["sa.`{$sa['reviewer']}` = ?"];
+$args  = [$me];
+if ($q   !== '') { $where[]="(u.name LIKE ? OR u.email LIKE ?)"; $args[]="%$q%"; $args[]="%$q%"; }
+if ($from!== '') { $where[]="d.log_date >= ?"; $args[]=$from; }
+if ($to  !== '') { $where[]="d.log_date <= ?"; $args[]=$to; }
+$sqlWhere = 'WHERE '.implode(' AND ', $where);
+
+/* query */
+$sql = "
+  SELECT d.id, d.user_id, d.log_date, d.activity, d.status, u.name, u.email
+  FROM daily_logs d
+  JOIN users u ON u.id = d.user_id
+  JOIN student_assignments sa ON sa.`{$sa['student']}` = u.id
+  $sqlWhere
+  ORDER BY d.log_date DESC, d.id DESC
+  LIMIT 200
+";
+$st=$pdo->prepare($sql); $st->execute($args); $rows=$st->fetchAll(PDO::FETCH_ASSOC);
+
+$title='Lecturer · Daily Logs';
+?>
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title><?= h($title) ?></title>
+<link rel="stylesheet" href="<?= $APP_BASE ?>/assets/style.css">
+</head><body>
+<?php include __DIR__.'/../app/header.php'; ?>
+<div class="container">
+  <h1>My Students · Daily Logs</h1>
+  <form method="get" class="filters" style="display:flex;gap:.5rem;flex-wrap:wrap;margin:.75rem 0 1rem">
+    <input name="q" value="<?= h($q) ?>" placeholder="Search student">
+    <input type="date" name="from" value="<?= h($from) ?>">
+    <input type="date" name="to" value="<?= h($to) ?>">
+    <button class="btn">Filter</button>
+  </form>
+  <table class="table">
+  <thead>
+    <tr><th>Date</th><th>Student</th><th>Activity</th><th>Status</th><th>Actions</th></tr>
+  </thead>
+  <tbody>
+    <?php foreach($rows as $r): ?>
+      <tr>
+        <td><?= h($r['log_date']) ?></td>
+        <td><?= h($r['name']) ?> <small>(<?= h($r['email']) ?>)</small></td>
+        <td><?= h($r['activity']) ?></td>
+        <td><span class="status <?= h(strtolower($r['status'])) ?>"><?= h($r['status']) ?></span></td>
+
+        <td>
+          <a class="btn small" href="<?= $APP_BASE ?>/lecturer/verify_daily.php?id=<?= (int)$r['id'] ?>">View / Verify</a>
+        </td>
+      </tr>
+    <?php endforeach; if(!$rows): ?>
+      <tr><td colspan="5">No results.</td></tr>
+    <?php endif; ?>
+  </tbody>
+</table>
+
+</div>
+</body></html>

--- a/INTERNS/lecturer/dashboard.php
+++ b/INTERNS/lecturer/dashboard.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__.'/../app/auth.php';  require_role(['lecturer']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+function table_exists(PDO $pdo, string $t): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name=? LIMIT 1");
+  $st->execute([$t]); return (bool)$st->fetchColumn();
+}
+function scalar(PDO $pdo,string $sql,array $p=[]): int {
+  $st=$pdo->prepare($sql); $st->execute($p); return (int)$st->fetchColumn();
+}
+
+$dailyTable = table_exists($pdo,'daily_logs') ? 'daily_logs' : (table_exists($pdo,'logs') ? 'logs' : null);
+
+$counts = [
+  'daily_pending'  => $dailyTable ? scalar($pdo, "SELECT COUNT(*) FROM `$dailyTable` WHERE status='submitted'") : 0,
+  'weekly_pending' => table_exists($pdo,'weekly_reports') ? scalar($pdo, "SELECT COUNT(*) FROM weekly_reports WHERE status='submitted'") : 0,
+  'leave_pending'  => table_exists($pdo,'leaves') ? scalar($pdo, "SELECT COUNT(*) FROM leaves WHERE status='pending'") : 0,
+];
+
+include __DIR__.'/../app/header.php';
+?>
+<h2>Lecturer Dashboard</h2>
+
+<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;margin-bottom:16px">
+  <div class="card" style="padding:14px;background:var(--card);border:1px solid var(--line);border-radius:10px">
+    <div>Daily logs awaiting review</div>
+    <div style="font-size:28px;font-weight:700;margin:.25rem 0"><?= (int)$counts['daily_pending'] ?></div>
+    <a class="btn" href="<?= url('/lecturer/verify_daily.php') ?>">Review daily logs</a>
+  </div>
+  <div class="card" style="padding:14px;background:var(--card);border:1px solid var(--line);border-radius:10px">
+    <div>Weekly reports awaiting review</div>
+    <div style="font-size:28px;font-weight:700;margin:.25rem 0"><?= (int)$counts['weekly_pending'] ?></div>
+    <a class="btn" href="<?= url('/lecturer/verify_weekly.php') ?>">Review weekly reports</a>
+  </div>
+  <div class="card" style="padding:14px;background:var(--card);border:1px solid var(--line);border-radius:10px">
+    <div>Leave requests awaiting review</div>
+    <div style="font-size:28px;font-weight:700;margin:.25rem 0"><?= (int)$counts['leave_pending'] ?></div>
+    <a class="btn" href="<?= url('/lecturer/verify_leaves.php') ?>">Review leave requests</a>
+  </div>
+</div>
+
+<h3>Quick links</h3>
+<ul>
+  <li><a href="<?= url('/lecturer/verify_daily.php') ?>">Verify Daily Logs</a></li>
+  <li><a href="<?= url('/lecturer/verify_weekly.php') ?>">Verify Weekly Reports</a></li>
+  <li><a href="<?= url('/lecturer/verify_leaves.php') ?>">Verify Leave Requests</a></li>
+</ul>
+
+</main></body></html>

--- a/INTERNS/lecturer/leaves_list.php
+++ b/INTERNS/lecturer/leaves_list.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors','1'); ini_set('display_startup_errors','1'); error_reporting(E_ALL);
+
+require_once __DIR__ . '/../app/config.php';
+$config = (isset($config) && is_array($config)) ? $config : (is_array(@require __DIR__ . '/../app/config.php') ? require __DIR__ . '/../app/config.php' : []);
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/helpers.php';
+require_role(['lecturer']);
+
+$me = (int)($_SESSION['user']['id'] ?? 0);
+function app_base(?array $cfg): string { return rtrim(defined('APP_BASE') ? (string)APP_BASE : (string)($cfg['APP_BASE']??''), '/'); }
+$APP_BASE = app_base($config);
+
+function sa_cols(PDO $pdo): array {
+  $have=function(array $c) use($pdo){$in=implode(',',array_fill(0,count($c),'?'));$st=$pdo->prepare("SELECT COUNT(*) FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name='student_assignments' AND column_name IN ($in)");$st->execute($c);return (int)$st->fetchColumn()===count($c);};
+  if ($have(['student_user_id','lecturer_user_id'])) return ['student'=>'student_user_id','reviewer'=>'lecturer_user_id'];
+  if ($have(['student_id','lecturer_id']))           return ['student'=>'student_id','reviewer'=>'lecturer_id'];
+  return ['student'=>'student_user_id','reviewer'=>'lecturer_user_id'];
+}
+$sa = sa_cols($pdo);
+
+/* filters */
+$q      = trim($_GET['q'] ?? '');
+$from   = trim($_GET['from'] ?? '');
+$to     = trim($_GET['to'] ?? '');
+$status = trim($_GET['status'] ?? '');
+
+$where = ["sa.`{$sa['reviewer']}` = ?"]; $args=[$me];
+if ($q     !== '') { $where[]="(u.name LIKE ? OR u.email LIKE ?)"; $args[]="%$q%"; $args[]="%$q%"; }
+if ($from  !== '') { $where[]="l.date_from >= ?"; $args[]=$from; }
+if ($to    !== '') { $where[]="l.date_to   <= ?"; $args[]=$to; }
+if ($status!== '') { $where[]="l.status = ?";     $args[]=$status; }
+$sqlWhere='WHERE '.implode(' AND ',$where);
+$statuses=['pending','approved','rejected'];
+
+/* query */
+$sql = "
+  SELECT l.id, l.user_id, l.date_from, l.date_to, l.reason, l.status, u.name, u.email
+  FROM leaves l
+  JOIN users u ON u.id = l.user_id
+  JOIN student_assignments sa ON sa.`{$sa['student']}` = u.id
+  $sqlWhere
+  ORDER BY l.date_from DESC, l.id DESC
+  LIMIT 200
+";
+$st=$pdo->prepare($sql); $st->execute($args); $rows=$st->fetchAll(PDO::FETCH_ASSOC);
+
+$title='Lecturer · Leaves';
+?>
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title><?= h($title) ?></title>
+<link rel="stylesheet" href="<?= $APP_BASE ?>/assets/style.css">
+</head><body>
+<?php include __DIR__.'/../app/header.php'; ?>
+<div class="container">
+  <h1>My Students · Leaves</h1>
+  <form method="get" class="filters" style="display:flex;gap:.5rem;flex-wrap:wrap;margin:.75rem 0 1rem">
+    <input name="q" value="<?= h($q) ?>" placeholder="Search student">
+    <input type="date" name="from" value="<?= h($from) ?>">
+    <input type="date" name="to" value="<?= h($to) ?>">
+    <select name="status">
+      <option value="">Any status</option>
+      <?php foreach($statuses as $s): ?><option value="<?= $s ?>" <?= $status===$s?'selected':'' ?>><?= ucfirst($s) ?></option><?php endforeach; ?>
+    </select>
+    <button class="btn">Filter</button>
+  </form>
+  <table class="table">
+  <thead>
+    <tr><th>Dates</th><th>Student</th><th>Reason</th><th>Status</th><th>Actions</th></tr>
+  </thead>
+  <tbody>
+    <?php foreach($rows as $r): ?>
+      <tr>
+        <td><?= h($r['date_from']) ?> → <?= h($r['date_to']) ?></td>
+        <td><?= h($r['name']) ?> <small>(<?= h($r['email']) ?>)</small></td>
+        <td><?= h(mb_strimwidth((string)$r['reason'], 0, 120, '…')) ?></td>
+        <td><span class="status <?= h(strtolower($r['status'])) ?>"><?= h($r['status']) ?></span></td>
+
+        <td>
+          <a class="btn small" href="<?= $APP_BASE ?>/lecturer/verify_leaves.php?id=<?= (int)$r['id'] ?>">View / Verify</a>
+        </td>
+      </tr>
+    <?php endforeach; if(!$rows): ?>
+      <tr><td colspan="5">No results.</td></tr>
+    <?php endif; ?>
+  </tbody>
+</table>
+
+</div>
+</body></html>

--- a/INTERNS/lecturer/verify_daily.php
+++ b/INTERNS/lecturer/verify_daily.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__.'/../app/auth.php'; require_role(['lecturer']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+  $id=(int)$_POST['id'];
+  $act=$_POST['action'] ?? '';
+  $cmt=trim($_POST['comment'] ?? '');
+  if(in_array($act,['approved','rejected'])){
+    $st=$pdo->prepare("UPDATE daily_logs SET status=?, reviewer_id=?, reviewer_comment=? WHERE id=?");
+    $st->execute([$act, $_SESSION['user']['id'], $cmt, $id]);
+  }
+}
+$rows=$pdo->query("SELECT d.*, u.name FROM daily_logs d JOIN users u ON u.id=d.user_id WHERE d.status IN ('submitted','rejected') ORDER BY d.log_date DESC")->fetchAll();
+include __DIR__.'/../app/header.php';
+?>
+<h2>Verify Daily Logs</h2>
+<table class="tbl">
+<tr><th>Date</th><th>Student</th><th>Activity</th><th>Hours</th><th>Action</th></tr>
+<?php foreach($rows as $r): ?>
+<tr>
+  <td><?= h($r['log_date']) ?></td>
+  <td><?= h($r['name']) ?></td>
+  <td><?= nl2br(h($r['activity'])) ?></td>
+  <td><?= h($r['hours']) ?></td>
+  <td>
+    <form method="post">
+      <input type="hidden" name="id" value="<?= (int)$r['id'] ?>">
+      <input name="comment" placeholder="comment">
+      <button name="action" value="approved">Approve</button>
+      <button name="action" value="rejected">Reject</button>
+    </form>
+  </td>
+</tr>
+<?php endforeach; ?>
+</table>
+</main></body></html>

--- a/INTERNS/lecturer/verify_leaves.php
+++ b/INTERNS/lecturer/verify_leaves.php
@@ -1,0 +1,121 @@
+<?php
+// lecturer/verify_leaves.php (resilient)
+declare(strict_types=1);
+require_once __DIR__.'/../app/auth.php';  require_role(['lecturer']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+ini_set('display_errors','1'); error_reporting(E_ALL);
+
+function col_exists(PDO $pdo, string $table, string $col): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name=? AND column_name=? LIMIT 1");
+  $st->execute([$table,$col]); return (bool)$st->fetchColumn();
+}
+
+// What columns do we actually have?
+$hasStatus   = col_exists($pdo,'leaves','status');
+$hasRevId    = col_exists($pdo,'leaves','reviewer_id');
+$hasRevCmt   = col_exists($pdo,'leaves','reviewer_comment');
+$hasDateCol  = col_exists($pdo,'leaves','leave_date');
+$hasDateAlt  = col_exists($pdo,'leaves','date');
+$dateCol     = $hasDateCol ? 'leave_date' : ($hasDateAlt ? 'date' : 'created_at');
+
+// Handle POST (approve/reject) only if status column exists
+if ($hasStatus && $_SERVER['REQUEST_METHOD']==='POST') {
+  $id  = (int)($_POST['id'] ?? 0);
+  $act = $_POST['action'] ?? '';
+  $cmt = trim($_POST['comment'] ?? '');
+  if ($id && in_array($act, ['approved','rejected'], true)) {
+    // build dynamic update
+    $sets = ["status=?"];
+    $vals = [$act];
+    if ($hasRevId)  { $sets[]="reviewer_id=?";      $vals[]=$_SESSION['user']['id']; }
+    if ($hasRevCmt) { $sets[]="reviewer_comment=?"; $vals[]=$cmt; }
+    $vals[] = $id;
+    $sql = "UPDATE leaves SET ".implode(',', $sets)." WHERE id=?";
+    $st  = $pdo->prepare($sql); $st->execute($vals);
+  }
+}
+
+// Build list query
+$filter   = $hasStatus ? ($_GET['status'] ?? 'pending') : 'all';
+$whereSql = $hasStatus && $filter!=='all' ? "WHERE l.status = :status" : "";
+$sql = "SELECT l.*, u.name 
+        FROM leaves l 
+        JOIN users u ON u.id=l.user_id 
+        $whereSql
+        ORDER BY l.$dateCol DESC, l.id DESC";
+$st = $pdo->prepare($sql);
+if ($whereSql) $st->bindValue(':status',$filter);
+$st->execute();
+$rows = $st->fetchAll();
+
+include __DIR__.'/../app/header.php';
+?>
+<h2>Verify Leave Requests (Lecturer)</h2>
+
+<?php if(!$hasStatus): ?>
+  <p class="error" style="white-space:pre-line">
+    Approve/Reject is disabled because your <code>leaves</code> table has no <code>status</code> column.
+    Add it with:
+    ALTER TABLE leaves
+      ADD COLUMN status ENUM('pending','approved','rejected') DEFAULT 'pending',
+      ADD COLUMN reviewer_id INT NULL,
+      ADD COLUMN reviewer_comment TEXT NULL;
+  </p>
+<?php endif; ?>
+
+<form method="get" style="margin:.5rem 0">
+  <?php if($hasStatus): ?>
+    <label>Status
+      <select name="status" onchange="this.form.submit()">
+        <option value="pending"  <?= $filter==='pending'?'selected':'' ?>>Pending</option>
+        <option value="approved" <?= $filter==='approved'?'selected':'' ?>>Approved</option>
+        <option value="rejected" <?= $filter==='rejected'?'selected':'' ?>>Rejected</option>
+        <option value="all"      <?= $filter==='all'?'selected':'' ?>>All</option>
+      </select>
+    </label>
+  <?php else: ?>
+    <em>Filtering requires a <code>status</code> column.</em>
+  <?php endif; ?>
+</form>
+
+<?php if (!$rows): ?>
+  <p>No leave requests found.</p>
+<?php else: ?>
+  <table class="tbl">
+    <tr>
+      <th><?= h(ucwords(str_replace('_',' ',$dateCol))) ?></th>
+      <th>Student</th>
+      <th>Reason</th>
+      <?php if($hasStatus): ?><th>Status</th><?php endif; ?>
+      <th>Review</th>
+    </tr>
+    <?php foreach ($rows as $r): ?>
+      <tr>
+        <td><?= h($r[$dateCol] ?? '') ?></td>
+        <td><?= h($r['name'] ?? '') ?></td>
+        <td style="max-width:420px"><?= nl2br(h($r['reason'] ?? '')) ?></td>
+        <?php if($hasStatus): ?><td><?= h($r['status']) ?></td><?php endif; ?>
+        <td>
+          <?php if($hasStatus && ($r['status'] ?? 'pending')==='pending'): ?>
+            <form method="post">
+              <input type="hidden" name="id" value="<?= (int)$r['id'] ?>">
+              <input name="comment" placeholder="comment" style="width:180px">
+              <button name="action" value="approved">Approve</button>
+              <button name="action" value="rejected">Reject</button>
+            </form>
+          <?php else: ?>
+            <?php if($hasRevCmt && !empty($r['reviewer_comment'])): ?>
+              <small><?= nl2br(h($r['reviewer_comment'])) ?></small>
+            <?php else: ?>
+              <em>—</em>
+            <?php endif; ?>
+          <?php endif; ?>
+        </td>
+      </tr>
+    <?php endforeach; ?>
+  </table>
+<?php endif; ?>
+
+</main></body></html>

--- a/INTERNS/lecturer/verify_weekly.php
+++ b/INTERNS/lecturer/verify_weekly.php
@@ -1,0 +1,85 @@
+<?php
+// lecturer/verify_weekly.php
+require_once __DIR__.'/../app/auth.php';  require_role(['lecturer']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+if ($_SERVER['REQUEST_METHOD']==='POST') {
+  $id  = (int)($_POST['id'] ?? 0);
+  $act = $_POST['action'] ?? '';
+  $cmt = trim($_POST['comment'] ?? '');
+  if ($id && in_array($act, ['approved','rejected'], true)) {
+    $st = $pdo->prepare("UPDATE weekly_reports SET status=?, reviewer_id=?, reviewer_comment=? WHERE id=?");
+    $st->execute([$act, $_SESSION['user']['id'], $cmt, $id]);
+  }
+}
+
+$filter = $_GET['status'] ?? 'submitted'; // submitted | approved | rejected | all
+$where  = ($filter==='all') ? '' : 'WHERE wr.status = ?';
+$sql    = "SELECT wr.*, u.name FROM weekly_reports wr JOIN users u ON u.id=wr.user_id $where ORDER BY wr.week_start DESC";
+$st     = $pdo->prepare($sql);
+($where ? $st->execute([$filter]) : $st->execute());
+$rows   = $st->fetchAll();
+
+$imgStmt = $pdo->prepare("SELECT path FROM weekly_images WHERE weekly_id=?");
+
+include __DIR__.'/../app/header.php';
+?>
+<h2>Verify Weekly Reports (Lecturer)</h2>
+
+<form method="get" style="margin:.5rem 0">
+  <label>Status
+    <select name="status" onchange="this.form.submit()">
+      <option value="submitted" <?= $filter==='submitted'?'selected':'' ?>>Submitted</option>
+      <option value="approved"  <?= $filter==='approved'?'selected':'' ?>>Approved</option>
+      <option value="rejected"  <?= $filter==='rejected'?'selected':'' ?>>Rejected</option>
+      <option value="all"       <?= $filter==='all'?'selected':'' ?>>All</option>
+    </select>
+  </label>
+</form>
+
+<?php if (!$rows): ?>
+  <p>No reports found.</p>
+<?php else: ?>
+  <table class="tbl">
+    <tr>
+      <th>Week</th>
+      <th>Student</th>
+      <th>Summary</th>
+      <th>Images</th>
+      <th>Status</th>
+      <th>Review</th>
+    </tr>
+    <?php foreach ($rows as $r): ?>
+      <?php $imgStmt->execute([$r['id']]); $imgs = $imgStmt->fetchAll(PDO::FETCH_COLUMN); ?>
+      <tr>
+        <td><?= h($r['week_start']) ?> → <?= h($r['week_end']) ?></td>
+        <td><?= h($r['name']) ?></td>
+        <td style="max-width:420px"><?= nl2br(h($r['summary'])) ?></td>
+        <td>
+          <?php if ($imgs): foreach ($imgs as $p): ?>
+            <a href="<?= url($p) ?>" target="_blank">
+              <img src="<?= url($p) ?>" alt="" style="height:50px;max-width:80px;object-fit:cover;margin-right:.25rem;border-radius:.25rem">
+            </a>
+          <?php endforeach; else: ?>
+            <em>—</em>
+          <?php endif; ?>
+        </td>
+        <td><?= h($r['status']) ?></td>
+        <td>
+          <?php if ($r['status']==='submitted'): ?>
+            <form method="post">
+              <input type="hidden" name="id" value="<?= (int)$r['id'] ?>">
+              <input name="comment" placeholder="comment" style="width:180px">
+              <button name="action" value="approved">Approve</button>
+              <button name="action" value="rejected">Reject</button>
+            </form>
+          <?php else: ?>
+            <small><?= h($r['reviewer_comment'] ?: '—') ?></small>
+          <?php endif; ?>
+        </td>
+      </tr>
+    <?php endforeach; ?>
+  </table>
+<?php endif; ?>
+</main></body></html>

--- a/INTERNS/lecturer/weekly_list.php
+++ b/INTERNS/lecturer/weekly_list.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors','1'); ini_set('display_startup_errors','1'); error_reporting(E_ALL);
+
+require_once __DIR__ . '/../app/config.php';
+$config = (isset($config) && is_array($config)) ? $config : (is_array(@require __DIR__ . '/../app/config.php') ? require __DIR__ . '/../app/config.php' : []);
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/helpers.php';
+require_role(['lecturer']);
+
+$me = (int)($_SESSION['user']['id'] ?? 0);
+function app_base(?array $cfg): string { return rtrim(defined('APP_BASE') ? (string)APP_BASE : (string)($cfg['APP_BASE']??''), '/'); }
+$APP_BASE = app_base($config);
+
+function sa_cols(PDO $pdo): array {
+  $have=function(array $c) use($pdo){$in=implode(',',array_fill(0,count($c),'?'));$st=$pdo->prepare("SELECT COUNT(*) FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name='student_assignments' AND column_name IN ($in)");$st->execute($c);return (int)$st->fetchColumn()===count($c);};
+  if ($have(['student_user_id','lecturer_user_id'])) return ['student'=>'student_user_id','reviewer'=>'lecturer_user_id'];
+  if ($have(['student_id','lecturer_id']))           return ['student'=>'student_id','reviewer'=>'lecturer_id'];
+  return ['student'=>'student_user_id','reviewer'=>'lecturer_user_id'];
+}
+$sa = sa_cols($pdo);
+
+/* filters */
+$q    = trim($_GET['q'] ?? '');
+$from = trim($_GET['from'] ?? '');
+$to   = trim($_GET['to'] ?? '');
+$dateExpr = "COALESCE(w.week_start, w.report_date, w.created_at)";
+
+$where = ["sa.`{$sa['reviewer']}` = ?"]; $args = [$me];
+if ($q !== '')    { $where[]="(u.name LIKE ? OR u.email LIKE ?)"; $args[]="%$q%"; $args[]="%$q%"; }
+if ($from!=='')   { $where[]="$dateExpr >= ?"; $args[]=$from; }
+if ($to  !=='')   { $where[]="$dateExpr <= ?"; $args[]=$to; }
+$sqlWhere = 'WHERE '.implode(' AND ', $where);
+
+/* query */
+$sql = "
+  SELECT
+    w.id, w.user_id, w.week_no, w.week_start, w.report_date, w.created_at, w.status,
+    COALESCE(w.activities_summary, w.activity_summary, w.highlights, '') AS summary,
+    COALESCE(w.week_start, w.report_date, w.created_at) AS week_val,
+    u.name, u.email
+  FROM weekly_reports w
+  JOIN users u ON u.id = w.user_id
+  JOIN student_assignments sa ON sa.`{$sa['student']}` = u.id
+  $sqlWhere
+  ORDER BY $dateExpr DESC, w.id DESC
+  LIMIT 200
+";
+$st=$pdo->prepare($sql); $st->execute($args); $rows=$st->fetchAll(PDO::FETCH_ASSOC);
+
+$title='Lecturer · Weekly Reports';
+?>
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title><?= h($title) ?></title>
+<link rel="stylesheet" href="<?= $APP_BASE ?>/assets/style.css">
+</head><body>
+<?php include __DIR__.'/../app/header.php'; ?>
+<div class="container">
+  <h1>My Students · Weekly Reports</h1>
+  <form method="get" class="filters" style="display:flex;gap:.5rem;flex-wrap:wrap;margin:.75rem 0 1rem">
+    <input name="q" value="<?= h($q) ?>" placeholder="Search student">
+    <input type="date" name="from" value="<?= h($from) ?>">
+    <input type="date" name="to" value="<?= h($to) ?>">
+    <button class="btn">Filter</button>
+  </form>
+  <table class="table">
+  <thead>
+    <tr><th>Week</th><th>Student</th><th>Summary</th><th>Status</th><th>Actions</th></tr>
+  </thead>
+  <tbody>
+    <?php foreach($rows as $r): ?>
+      <tr>
+        <td>
+          <?= h($r['week_val']) ?>
+          <?php if (!empty($r['week_no'])): ?>
+            <small>(Week <?= (int)$r['week_no'] ?>)</small>
+          <?php endif; ?>
+        </td>
+        <td><?= h($r['name']) ?> <small>(<?= h($r['email']) ?>)</small></td>
+        <td><?= h(mb_strimwidth((string)$r['summary'], 0, 120, '…')) ?></td>
+        <td><span class="status <?= h(strtolower($r['status'])) ?>"><?= h($r['status']) ?></span></td>
+
+        <td>
+          <a class="btn small" href="<?= $APP_BASE ?>/lecturer/verify_weekly.php?id=<?= (int)$r['id'] ?>">View / Verify</a>
+        </td>
+      </tr>
+    <?php endforeach; if(!$rows): ?>
+      <tr><td colspan="5">No results.</td></tr>
+    <?php endif; ?>
+  </tbody>
+</table>
+
+</div>
+</body></html>

--- a/INTERNS/ping.php
+++ b/INTERNS/ping.php
@@ -1,0 +1,1 @@
+<?php echo "ping-ok"; ?>

--- a/INTERNS/profile.php
+++ b/INTERNS/profile.php
@@ -1,0 +1,343 @@
+<?php
+declare(strict_types=1); // must be first
+
+// Dev error visibility (remove later if you like)
+ini_set('display_errors','1');
+ini_set('display_startup_errors','1');
+ini_set('log_errors','1');
+error_reporting(E_ALL);
+
+require_once __DIR__ . '/app/session.php';
+require_once __DIR__ . '/app/db.php';
+require_once __DIR__ . '/app/helpers.php';
+
+if (!function_exists('h')) {
+  function h(?string $s): string { return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }
+}
+
+/* ===== Require login ===== */
+if (empty($_SESSION['user']['id'])) {
+  header('Location: ' . url('/auth/login.php')); exit;
+}
+$me     = $_SESSION['user'];
+$userId = (int)$me['id'];
+$role   = strtolower((string)($me['role'] ?? ''));
+
+/* ===== Small helpers ===== */
+function table_exists(PDO $pdo, string $name): bool {
+  $q = $pdo->prepare("SELECT 1 FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name=? LIMIT 1");
+  $q->execute([$name]); return (bool)$q->fetchColumn();
+}
+function cols(PDO $pdo, string $table): array {
+  $rows = $pdo->query("SHOW COLUMNS FROM `$table`")->fetchAll(PDO::FETCH_ASSOC);
+  $out = [];
+  foreach ($rows as $r) $out[strtolower($r['Field'])] = strtolower($r['Type'] ?? '');
+  return $out;
+}
+function active_sql(string $col = 'status'): string {
+  // Works for numeric or text status columns
+  return " ( $col IS NULL OR $col='' OR $col='active' OR $col='1' OR $col=1 OR $col='enabled' OR $col='approved' ) ";
+}
+function include_first(array $relativePaths): void {
+  foreach ($relativePaths as $rel) {
+    $p = __DIR__ . $rel;
+    if (file_exists($p)) { include $p; return; }
+  }
+}
+
+/* ===== Load my user row ===== */
+$u = $pdo->prepare("SELECT * FROM users WHERE id=? LIMIT 1");
+$u->execute([$userId]);
+$userRow = $u->fetch(PDO::FETCH_ASSOC) ?: [];
+
+/* ===== Students table / row ===== */
+$studentsTblExists = table_exists($pdo, 'students');
+$studentRow = [];
+$studentUserCol = null;
+if ($studentsTblExists) {
+  $sCols = cols($pdo, 'students');
+  $studentUserCol = array_key_exists('user_id', $sCols) ? 'user_id'
+                  : (array_key_exists('student_id', $sCols) ? 'student_id' : null);
+  if ($studentUserCol) {
+    $s = $pdo->prepare("SELECT * FROM `students` WHERE `$studentUserCol`=? LIMIT 1");
+    $s->execute([$userId]);
+    $studentRow = $s->fetch(PDO::FETCH_ASSOC) ?: [];
+  }
+}
+
+/* ===== Student assignments table (create if missing) ===== */
+if (!table_exists($pdo, 'student_assignments')) {
+  $pdo->exec("
+    CREATE TABLE `student_assignments` (
+      `student_id`     INT NOT NULL,
+      `lecturer_id`    INT DEFAULT NULL,
+      `supervisor_id`  INT DEFAULT NULL,
+      `status`         VARCHAR(20) NOT NULL DEFAULT 'pending',
+      `created_at`     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      `updated_at`     TIMESTAMP NULL DEFAULT NULL,
+      INDEX (`student_id`), INDEX (`lecturer_id`), INDEX (`supervisor_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+  ");
+}
+$aCols = cols($pdo, 'student_assignments');
+$aStudentCol    = array_key_exists('student_id',    $aCols) ? 'student_id'    : (array_key_exists('student_user_id', $aCols) ? 'student_user_id' : null);
+$aLecturerCol   = array_key_exists('lecturer_id',   $aCols) ? 'lecturer_id'   : (array_key_exists('lecturer_user_id',$aCols) ? 'lecturer_user_id' : null);
+$aSupervisorCol = array_key_exists('supervisor_id', $aCols) ? 'supervisor_id' : (array_key_exists('sv_id',          $aCols) ? 'sv_id'           : null);
+$aStatusCol     = array_key_exists('status',        $aCols) ? 'status'        : null;
+
+/* ===== Handle POST (1) edit profile, (2) save assignment) ===== */
+$notice = ''; $errors = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $action = $_POST['_action'] ?? '';
+
+  // (1) Student profile save
+  if ($role === 'student' && $action === 'save_profile') {
+    $name       = trim($_POST['name'] ?? '');
+    $email      = trim($_POST['email'] ?? '');
+    $matric_no  = trim($_POST['matric_no'] ?? '');
+    $start_date = trim($_POST['start_date'] ?? '');
+    $end_date   = trim($_POST['end_date'] ?? '');
+
+    if ($name === '') $errors['name'] = 'Name is required.';
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) $errors['email'] = 'Valid email is required.';
+    if (!$errors) {
+      $chk = $pdo->prepare("SELECT id FROM users WHERE email=? AND id<>? LIMIT 1");
+      $chk->execute([$email, $userId]);
+      if ($chk->fetch()) $errors['email'] = 'Email already used by another account.';
+    }
+
+    if (!$errors) {
+      // update users
+      $uCols = cols($pdo, 'users');
+      $set = []; $vals=[];
+      if (array_key_exists('name',$uCols))  { $set[]="`name`=?";  $vals[]=$name; }
+      if (array_key_exists('email',$uCols)) { $set[]="`email`=?"; $vals[]=$email; }
+      if ($set) {
+        $vals[] = $userId;
+        $pdo->prepare("UPDATE `users` SET ".implode(',', $set)." WHERE id=?")->execute($vals);
+        $_SESSION['user']['name']  = $name;
+        $_SESSION['user']['email'] = $email;
+      }
+      // upsert students
+      if ($studentsTblExists && $studentUserCol) {
+        $sCols2 = cols($pdo, 'students');
+        $payload = [];
+        if (array_key_exists('matric_no', $sCols2))  $payload['matric_no']  = ($matric_no !== '' ? $matric_no : null);
+        if (array_key_exists('start_date',$sCols2))  $payload['start_date'] = ($start_date !== '' ? $start_date : null);
+        if (array_key_exists('end_date',  $sCols2))  $payload['end_date']   = ($end_date   !== '' ? $end_date   : null);
+
+        $exists = !empty($studentRow);
+        if ($exists) {
+          if ($payload) {
+            $parts=[]; $vals=[];
+            foreach ($payload as $k=>$v){ $parts[]="`$k`=?"; $vals[]=$v; }
+            $vals[]=$userId;
+            $pdo->prepare("UPDATE `students` SET ".implode(',', $parts)." WHERE `$studentUserCol`=?")->execute($vals);
+          }
+        } else {
+          $payload[$studentUserCol] = $userId;
+          $colsList = implode(',', array_map(fn($k)=>"`$k`", array_keys($payload)));
+          $q = implode(',', array_fill(0, count($payload), '?'));
+          $pdo->prepare("INSERT INTO `students` ($colsList) VALUES ($q)")->execute(array_values($payload));
+        }
+      }
+      $notice = 'Profile updated.';
+      // refresh
+      if ($studentsTblExists && $studentUserCol) {
+        $s = $pdo->prepare("SELECT * FROM `students` WHERE `$studentUserCol`=? LIMIT 1");
+        $s->execute([$userId]);
+        $studentRow = $s->fetch(PDO::FETCH_ASSOC) ?: [];
+      }
+      $u = $pdo->prepare("SELECT * FROM users WHERE id=? LIMIT 1");
+      $u->execute([$userId]);
+      $userRow = $u->fetch(PDO::FETCH_ASSOC) ?: $userRow;
+    }
+  }
+
+  // (2) Student assignment save
+  if ($role === 'student' && $action === 'save_assignment' && $aStudentCol) {
+    $lecturer_id   = max(0, (int)($_POST['lecturer_id'] ?? 0));
+    $supervisor_id = max(0, (int)($_POST['supervisor_id'] ?? 0));
+
+    // validate chosen users
+    if ($lecturer_id) {
+      $q=$pdo->prepare("SELECT id FROM users WHERE id=? AND LOWER(role)='lecturer' AND ".active_sql('status')." LIMIT 1");
+      $q->execute([$lecturer_id]); if(!$q->fetch()) $lecturer_id=0;
+    }
+    if ($supervisor_id) {
+      $q=$pdo->prepare("SELECT id FROM users WHERE id=? AND LOWER(role)='supervisor' AND ".active_sql('status')." LIMIT 1");
+      $q->execute([$supervisor_id]); if(!$q->fetch()) $supervisor_id=0;
+    }
+
+    // upsert to student_assignments (status -> pending)
+    $st = $pdo->prepare("SELECT * FROM `student_assignments` WHERE `$aStudentCol`=? LIMIT 1");
+    $st->execute([$userId]);
+    $existing = $st->fetch(PDO::FETCH_ASSOC);
+
+    $parts=[]; $vals=[];
+    if ($aLecturerCol)   { $parts[]="`$aLecturerCol`=?";   $vals[] = $lecturer_id ?: null; }
+    if ($aSupervisorCol) { $parts[]="`$aSupervisorCol`=?"; $vals[] = $supervisor_id ?: null; }
+    if ($aStatusCol)     { $parts[]="`$aStatusCol`=?";     $vals[] = 'pending'; }
+    if (array_key_exists('updated_at',$aCols)) $parts[]="`updated_at`=CURRENT_TIMESTAMP";
+
+    if ($existing) {
+      $vals[] = $userId;
+      $pdo->prepare("UPDATE `student_assignments` SET ".implode(',', $parts)." WHERE `$aStudentCol`=?")->execute($vals);
+      $notice = 'Assignment updated (pending approval).';
+    } else {
+      $payload = [];
+      $payload[$aStudentCol] = $userId;
+      if ($aLecturerCol)   $payload[$aLecturerCol]   = $lecturer_id ?: null;
+      if ($aSupervisorCol) $payload[$aSupervisorCol] = $supervisor_id ?: null;
+      if ($aStatusCol)     $payload[$aStatusCol]     = 'pending';
+      $colsList = implode(',', array_map(fn($k)=>"`$k`", array_keys($payload)));
+      $q = implode(',', array_fill(0, count($payload), '?'));
+      $pdo->prepare("INSERT INTO `student_assignments` ($colsList) VALUES ($q)")->execute(array_values($payload));
+      $notice = 'Assignment saved (pending approval).';
+    }
+  }
+}
+
+/* ===== Data for display ===== */
+$name      = (string)($userRow['name']  ?? '');
+$email     = (string)($userRow['email'] ?? '');
+$matricNo  = (string)($studentRow['matric_no']  ?? '');
+$startDate = (string)($studentRow['start_date'] ?? '');
+$endDate   = (string)($studentRow['end_date']   ?? '');
+
+$assignment = null;
+if ($aStudentCol) {
+  $st = $pdo->prepare("SELECT * FROM `student_assignments` WHERE `$aStudentCol`=? LIMIT 1");
+  $st->execute([$userId]);
+  $assignment = $st->fetch(PDO::FETCH_ASSOC) ?: null;
+}
+$currentLecturerId   = (int)($assignment[$aLecturerCol]   ?? 0);
+$currentSupervisorId = (int)($assignment[$aSupervisorCol] ?? 0);
+
+$lecturers   = $pdo->query("SELECT id,name,email FROM users WHERE LOWER(role)='lecturer'  AND ".active_sql('status')." ORDER BY name")->fetchAll(PDO::FETCH_ASSOC) ?: [];
+$supervisors = $pdo->query("SELECT id,name,email FROM users WHERE LOWER(role)='supervisor' AND ".active_sql('status')." ORDER BY name")->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+?>
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Profile · INTERNS</title>
+  <link rel="stylesheet" href="<?= url('/assets/style.css') ?>">
+</head>
+<body>
+
+  <?php
+  // Use your existing topbar/header if present (NO new markup created here)
+  include_first([
+    '/partials/topbar.php','/partials/header.php',
+    '/includes/topbar.php','/includes/header.php',
+    '/inc/topbar.php','/inc/header.php',
+    '/layout/topbar.php','/layout/header.php'
+  ]);
+
+  // Use your existing sidebar if present
+  include_first([
+    '/partials/sidebar.php','/includes/sidebar.php',
+    '/inc/sidebar.php','/layout/sidebar.php'
+  ]);
+  ?>
+
+  <main class="container"><!-- your CSS controls layout with existing header/sidebar -->
+    <h2>My Profile</h2>
+
+    <?php if ($notice): ?>
+      <div class="ok" style="margin-bottom:.75rem"><?= h($notice) ?></div>
+    <?php endif; ?>
+    <?php if ($errors): ?>
+      <div class="error-list" style="margin-bottom:.75rem">
+        <?php foreach ($errors as $e): ?><div class="error"><?= h($e) ?></div><?php endforeach; ?>
+      </div>
+    <?php endif; ?>
+
+    <?php if ($role === 'student'): ?>
+      <!-- Edit profile -->
+      <div class="auth-card" style="background:var(--card);padding:1rem;border:1px solid var(--line);border-radius:.75rem;max-width:820px">
+        <h3 style="margin-top:0">Edit profile</h3>
+        <form method="post" novalidate>
+          <input type="hidden" name="_action" value="save_profile">
+          <label>Name
+            <input type="text" name="name" value="<?= h($name) ?>" required>
+          </label>
+          <label>Email
+            <input type="email" name="email" value="<?= h($email) ?>" required>
+          </label>
+          <?php if ($studentsTblExists): ?>
+            <label>Matric No.
+              <input type="text" name="matric_no" value="<?= h($matricNo) ?>">
+            </label>
+            <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px">
+              <label>Start Date
+                <input type="date" name="start_date" value="<?= h($startDate) ?>">
+              </label>
+              <label>End Date
+                <input type="date" name="end_date" value="<?= h($endDate) ?>">
+              </label>
+            </div>
+          <?php endif; ?>
+          <button class="btn" style="margin-top:.5rem">Save changes</button>
+        </form>
+      </div>
+
+      <div style="height:12px"></div>
+
+      <!-- Assign Lecturer & Supervisor -->
+      <div class="auth-card" style="background:var(--card);padding:1rem;border:1px solid var(--line);border-radius:.75rem;max-width:820px">
+        <h3 style="margin-top:0">Assigned Lecturer & Supervisor</h3>
+
+        <form method="post">
+          <input type="hidden" name="_action" value="save_assignment">
+          <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:12px">
+            <label>Lecturer
+              <select name="lecturer_id">
+                <option value="0">— Select lecturer —</option>
+                <?php foreach ($lecturers as $L): ?>
+                  <option value="<?= (int)$L['id'] ?>" <?= $currentLecturerId===(int)$L['id']?'selected':'' ?>>
+                    <?= h($L['name'] ?? 'Unknown') ?> (<?= h($L['email'] ?? '') ?>)
+                  </option>
+                <?php endforeach; ?>
+              </select>
+            </label>
+
+            <label>Supervisor
+              <select name="supervisor_id">
+                <option value="0">— Select supervisor —</option>
+                <?php foreach ($supervisors as $S): ?>
+                  <option value="<?= (int)$S['id'] ?>" <?= $currentSupervisorId===(int)$S['id']?'selected':'' ?>>
+                    <?= h($S['name'] ?? 'Unknown') ?> (<?= h($S['email'] ?? '') ?>)
+                  </option>
+                <?php endforeach; ?>
+              </select>
+            </label>
+          </div>
+
+          <button class="btn" style="margin-top:.75rem">Save</button>
+          <?php if ($aStatusCol && $assignment): ?>
+            <div style="margin-top:.5rem">Current status:
+              <span class="status <?= h(strtolower((string)$assignment[$aStatusCol])) ?>">
+                <?= h((string)$assignment[$aStatusCol]) ?>
+              </span>
+            </div>
+          <?php endif; ?>
+        </form>
+      </div>
+
+    <?php else: ?>
+      <!-- Non-student: read-only -->
+      <div class="auth-card" style="background:var(--card);padding:1rem;border:1px solid var(--line);border-radius:.75rem;max-width:820px">
+        <h3 style="margin-top:0">Account</h3>
+        <div><strong>Name:</strong> <?= h($userRow['name'] ?? '') ?></div>
+        <div><strong>Email:</strong> <?= h($userRow['email'] ?? '') ?></div>
+        <div><strong>Role:</strong> <?= h($role) ?></div>
+      </div>
+    <?php endif; ?>
+  </main>
+
+</body>
+</html>

--- a/INTERNS/student/daily_list.php
+++ b/INTERNS/student/daily_list.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors','1'); ini_set('display_startup_errors','1'); error_reporting(E_ALL);
+
+require_once __DIR__ . '/../app/config.php';
+$config = (isset($config) && is_array($config)) ? $config : (is_array(@require __DIR__ . '/../app/config.php') ? require __DIR__ . '/../app/config.php' : []);
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/helpers.php';
+require_role(['student']);
+
+$me = (int)($_SESSION['user']['id'] ?? 0);
+
+function app_base(?array $cfg): string {
+  return rtrim(defined('APP_BASE') ? (string)APP_BASE : (string)($cfg['APP_BASE'] ?? ''), '/');
+}
+$APP_BASE = app_base($config);
+
+/* Filters */
+$q    = trim($_GET['q'] ?? '');
+$from = trim($_GET['from'] ?? '');
+$to   = trim($_GET['to'] ?? '');
+
+$where = ["d.user_id = ?"]; $args = [$me];
+if ($q   !== '') { $where[]="d.activity LIKE ?"; $args[]="%$q%"; }
+if ($from!== '') { $where[]="d.log_date >= ?";   $args[]=$from;  }
+if ($to  !== '') { $where[]="d.log_date <= ?";   $args[]=$to;    }
+$sqlWhere = 'WHERE '.implode(' AND ', $where);
+
+/* Query */
+$sql = "
+  SELECT d.id, d.log_date, d.activity, d.status
+  FROM daily_logs d
+  $sqlWhere
+  ORDER BY d.log_date DESC, d.id DESC
+  LIMIT 500
+";
+$st=$pdo->prepare($sql); $st->execute($args); $rows=$st->fetchAll(PDO::FETCH_ASSOC);
+
+/* CSV export */
+if (isset($_GET['export']) && $_GET['export'] === 'csv') {
+  header('Content-Type: text/csv');
+  header('Content-Disposition: attachment; filename="my_daily_logs.csv"');
+  $out = fopen('php://output', 'w');
+  fputcsv($out, ['Date','Activity','Status']);
+  foreach ($rows as $r) {
+    fputcsv($out, [$r['log_date'], $r['activity'], $r['status']]);
+  }
+  exit;
+}
+
+$title = 'Student · My Daily Logs';
+?>
+<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title><?= h($title) ?></title>
+<link rel="stylesheet" href="<?= $APP_BASE ?>/assets/style.css">
+</head><body>
+<?php include __DIR__.'/../app/header.php'; ?>
+<div class="container">
+  <h1>My Daily Logs</h1>
+
+  <form method="get" class="filters" style="display:flex;gap:.5rem;flex-wrap:wrap;margin:.75rem 0 1rem">
+    <input name="q" value="<?= h($q) ?>" placeholder="Search activity">
+    <input type="date" name="from" value="<?= h($from) ?>">
+    <input type="date" name="to"   value="<?= h($to) ?>">
+    <button class="btn">Filter</button>
+    <button class="btn" name="export" value="csv">Export CSV</button>
+  </form>
+
+  <table class="table">
+    <thead><tr><th>Date</th><th>Activity</th><th>Status</th></tr></thead>
+    <tbody>
+      <?php foreach ($rows as $r): ?>
+        <tr>
+          <td><?= h($r['log_date']) ?></td>
+          <td><?= h($r['activity']) ?></td>
+          <td><span class="status <?= h(strtolower($r['status'])) ?>"><?= h($r['status']) ?></span></td>
+        </tr>
+      <?php endforeach; if(!$rows): ?>
+        <tr><td colspan="3">No results.</td></tr>
+      <?php endif; ?>
+    </tbody>
+  </table>
+</div>
+</body></html>

--- a/INTERNS/student/daily_new.php
+++ b/INTERNS/student/daily_new.php
@@ -1,0 +1,168 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__.'/../app/auth.php';  require_role(['student']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+$msg=''; $err='';
+
+function table_exists(PDO $pdo, string $t): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name=? LIMIT 1");
+  $st->execute([$t]); return (bool)$st->fetchColumn();
+}
+function col_exists(PDO $pdo, string $t, string $c): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name=? AND column_name=? LIMIT 1");
+  $st->execute([$t,$c]); return (bool)$st->fetchColumn();
+}
+
+$dailyTable = table_exists($pdo,'daily_logs') ? 'daily_logs' : (table_exists($pdo,'logs') ? 'logs' : 'daily_logs');
+$imgTable   = table_exists($pdo,'daily_images') ? 'daily_images' : (table_exists($pdo,'log_images') ? 'log_images' : 'daily_images');
+
+$uid = (int)($_SESSION['user']['id'] ?? 0);
+
+if ($_SERVER['REQUEST_METHOD']==='POST') {
+  $log_date  = $_POST['log_date'] ?? '';
+  $hari_post = trim($_POST['hari'] ?? '');
+  $tugas     = trim($_POST['tugas'] ?? '');
+  $objektif  = trim($_POST['objektif'] ?? '');
+  $peralatan = trim($_POST['peralatan'] ?? '');
+  $prosedur  = trim($_POST['prosedur'] ?? '');
+  $kesimpulan= trim($_POST['kesimpulan'] ?? '');
+
+  if (!$log_date || !$tugas || !$objektif || !$prosedur || !$kesimpulan) {
+    $err = 'Sila isi TARIKH, TUGAS/AKTIVITI/PROJEK, OBJEKTIF, PROSEDUR KERJA dan KESIMPULAN.';
+  }
+
+  // derive HARI (Malay) on the server too
+  $hari = $hari_post;
+  if (!$hari && $log_date) {
+    $names = ['Ahad','Isnin','Selasa','Rabu','Khamis','Jumaat','Sabtu'];
+    $hari = $names[(int)date('w', strtotime($log_date))] ?? '';
+  }
+
+  if (!$err) {
+    try {
+      // Build dynamic insert with whatever columns exist
+      $base = [
+        'user_id'   => $uid,
+        'log_date'  => $log_date,
+        'hari'      => $hari,
+        'tugas'     => $tugas,
+        'objektif'  => $objektif,
+        'peralatan' => $peralatan,
+        'prosedur'  => $prosedur,
+        'kesimpulan'=> $kesimpulan,
+        'status'    => 'submitted',
+      ];
+      $colsAvail = [];
+      foreach ($base as $k=>$v) if (col_exists($pdo,$dailyTable,$k)) $colsAvail[$k]=$v;
+
+      // Always ensure user_id/log_date exist
+      if (empty($colsAvail['user_id']) || empty($colsAvail['log_date'])) {
+        throw new RuntimeException("Jadual harian anda belum mempunyai lajur wajib (user_id/log_date).");
+      }
+
+      $cList = implode(',', array_map(fn($c)=>"`$c`", array_keys($colsAvail)));
+      $place = implode(',', array_fill(0,count($colsAvail),'?'));
+      $st = $pdo->prepare("INSERT INTO `$dailyTable` ($cList) VALUES ($place)");
+      $st->execute(array_values($colsAvail));
+      $daily_id = (int)$pdo->lastInsertId();
+
+      // Upload images (optional)
+      if (!empty($_FILES['images']['name'][0])) {
+        $dir = __DIR__.'/../uploads/daily';
+        if (!is_dir($dir)) { @mkdir($dir, 0775, true); }
+
+        $fk = col_exists($pdo,$imgTable,'daily_id') ? 'daily_id' : (col_exists($pdo,$imgTable,'log_id') ? 'log_id' : 'daily_id');
+        $imgStmt = $pdo->prepare("INSERT INTO `$imgTable` (`$fk`, `path`) VALUES (?,?)");
+
+        $files = $_FILES['images'];
+        $finfo = new finfo(FILEINFO_MIME_TYPE);
+
+        for ($i=0; $i<count($files['name']); $i++) {
+          if ($files['error'][$i] !== UPLOAD_ERR_OK) continue;
+          $tmp  = $files['tmp_name'][$i];
+          $mime = $finfo->file($tmp);
+          if (strpos($mime,'image/') !== 0) continue;
+          if (filesize($tmp) > 5*1024*1024) continue;
+
+          $ext  = strtolower(pathinfo($files['name'][$i], PATHINFO_EXTENSION));
+          $safe = preg_replace('/[^a-zA-Z0-9._-]/','_', pathinfo($files['name'][$i], PATHINFO_FILENAME));
+          $name = sprintf('%s_%d_%s.%s', date('YmdHis'), $uid, $safe, $ext);
+          $dest = $dir.'/'.$name;
+          if (move_uploaded_file($tmp, $dest)) {
+            $web = '/uploads/daily/'.$name;
+            $imgStmt->execute([$daily_id, $web]);
+          }
+        }
+      }
+
+      $msg = 'Laporan harian berjaya dihantar.';
+    } catch (Throwable $e) {
+      $err = 'Gagal menyimpan: '.$e->getMessage();
+    }
+  }
+}
+
+include __DIR__.'/../app/header.php';
+?>
+<h2>Daily Log</h2>
+<?php if($msg):?><p class="ok"><?= h($msg) ?></p><?php endif; ?>
+<?php if($err):?><p class="error"><?= h($err) ?></p><?php endif; ?>
+
+<form method="post" enctype="multipart/form-data">
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
+    <label>DAY
+      <input name="hari" id="hari" placeholder="cth: Isnin">
+    </label>
+    <label>DATE
+      <input type="date" name="log_date" id="log_date" required>
+    </label>
+  </div>
+
+  <label>PROJECT
+    <textarea name="tugas" rows="2" required></textarea>
+  </label>
+
+  <label>OBJECTIVE
+    <textarea name="objektif" rows="3" required></textarea>
+  </label>
+
+  <label>TOOLS (optional)
+    <textarea name="peralatan" rows="2"></textarea>
+  </label>
+
+  <label>WORK PROCEDURE
+    <textarea name="prosedur" rows="8" required></textarea>
+  </label>
+
+  <label>CONCLUSION
+    <textarea name="kesimpulan" rows="5" required></textarea>
+  </label>
+
+  <label>UPLOAD PHOTOS
+    <input type="file" name="images[]" accept="image/*" multiple>
+  </label>
+
+  <button class="btn">Submit</button>
+</form>
+
+<p><a href="<?= url('/student/daily_list.php') ?>">See my recorded reports</a></p>
+<p><a href="<?= url('/student/dashboard.php') ?>">Back to Dashboard</a></p>
+
+<script>
+// Auto-fill "HARI" from TARIKH in Malay
+(function(){
+  const days = ['Ahad','Isnin','Selasa','Rabu','Khamis','Jumaat','Sabtu'];
+  const d = document.getElementById('log_date');
+  const h = document.getElementById('hari');
+  if (d && h) d.addEventListener('change', () => {
+    const val = d.value;
+    if (!val) return;
+    const dt = new Date(val+'T12:00:00'); // avoid TZ edge
+    h.value = days[dt.getDay()] || '';
+  });
+})();
+</script>
+
+</main></body></html>

--- a/INTERNS/student/daily_pdf.php
+++ b/INTERNS/student/daily_pdf.php
@@ -1,0 +1,143 @@
+<?php
+// student/daily_pdf.php
+declare(strict_types=1);
+require_once __DIR__.'/../app/auth.php';  require_role(['student']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+$id  = (int)($_GET['id'] ?? 0);
+$uid = (int)($_SESSION['user']['id'] ?? 0);
+
+function table_exists(PDO $pdo, string $t): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name=? LIMIT 1");
+  $st->execute([$t]); return (bool)$st->fetchColumn();
+}
+function col_exists(PDO $pdo, string $t, string $c): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name=? AND column_name=? LIMIT 1");
+  $st->execute([$t,$c]); return (bool)$st->fetchColumn();
+}
+
+$dailyTable = table_exists($pdo,'daily_logs') ? 'daily_logs' : (table_exists($pdo,'logs') ? 'logs' : 'daily_logs');
+$imgTable   = table_exists($pdo,'daily_images') ? 'daily_images' : (table_exists($pdo,'log_images') ? 'log_images' : 'daily_images');
+$dateCol    = col_exists($pdo,$dailyTable,'log_date') ? 'log_date' : (col_exists($pdo,$dailyTable,'date') ? 'date' : 'created_at');
+$fk         = col_exists($pdo,$imgTable,'daily_id') ? 'daily_id' : (col_exists($pdo,$imgTable,'log_id') ? 'log_id' : 'daily_id');
+
+// fetch the entry (owned by current user)
+$st = $pdo->prepare("SELECT * FROM `$dailyTable` WHERE id=? AND user_id=? LIMIT 1");
+$st->execute([$id,$uid]);
+$log = $st->fetch();
+if (!$log) { http_response_code(404); echo "Not found"; exit; }
+
+// images
+$si = $pdo->prepare("SELECT path FROM `$imgTable` WHERE `$fk`=? ORDER BY id ASC");
+$si->execute([$id]);
+$imgs = $si->fetchAll(PDO::FETCH_COLUMN);
+
+$hari       = $log['hari']        ?? '';
+$tarikh     = $log[$dateCol]      ?? '';
+$tugas      = $log['tugas']       ?? ($log['activity'] ?? '');
+$objektif   = $log['objektif']    ?? '';
+$peralatan  = $log['peralatan']   ?? '';
+$prosedur   = $log['prosedur']    ?? '';
+$kesimpulan = $log['kesimpulan']  ?? '';
+$status     = $log['status']      ?? '';
+
+$config = require __DIR__.'/../app/config.php';
+$base   = rtrim($config['APP_BASE'],'/');
+
+// convert web path (/uploads/...) to disk path for Dompdf images
+function web_to_disk(string $web): string {
+  $clean = ltrim($web,'/');
+  return realpath(__DIR__ . '/../' . $clean) ?: (__DIR__ . '/../' . $clean);
+}
+
+// Build HTML for PDF/print
+ob_start(); ?>
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Laporan Harian</title>
+<style>
+  body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial; margin:28px; font-size:13px; color:#111}
+  h1{font-size:20px;margin:0 0 8px}
+  .meta{margin-bottom:10px}
+  .row{display:flex;gap:12px;margin-bottom:8px}
+  .col{flex:1}
+  .label{font-weight:700;margin-bottom:4px}
+  .box{border:1px solid #bbb; border-radius:6px; padding:8px; min-height:44px}
+  table{width:100%; border-collapse:collapse; margin-top:10px}
+  th,td{border:1px solid #bbb; padding:6px 8px; vertical-align:top}
+  .imgs{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
+  .imgs img{height:120px; object-fit:cover; border:1px solid #bbb; border-radius:4px}
+  .badge{display:inline-block; padding:2px 8px; border-radius:999px; background:#eee; font-size:12px}
+  @media print { .noprint{display:none} }
+</style>
+</head>
+<body>
+  <div class="noprint" style="text-align:right;margin-bottom:6px">
+    <button onclick="window.print()">Print / Save as PDF</button>
+  </div>
+
+  <h1>Laporan Harian</h1>
+  <div class="meta">
+    <?php if($status!==''): ?><span class="badge">Status: <?= htmlspecialchars($status) ?></span><?php endif; ?>
+  </div>
+
+  <div class="row">
+    <div class="col">
+      <div class="label">HARI</div>
+      <div class="box"><?= htmlspecialchars($hari) ?></div>
+    </div>
+    <div class="col">
+      <div class="label">TARIKH</div>
+      <div class="box"><?= htmlspecialchars($tarikh) ?></div>
+    </div>
+  </div>
+
+  <div class="label">TUGAS/AKTIVITI/PROJEK</div>
+  <div class="box"><?= nl2br(htmlspecialchars($tugas)) ?></div>
+
+  <div class="label" style="margin-top:8px">OBJEKTIF</div>
+  <div class="box"><?= nl2br(htmlspecialchars($objektif)) ?></div>
+
+  <div class="label" style="margin-top:8px">PERALATAN (jika perlu)</div>
+  <div class="box"><?= nl2br(htmlspecialchars($peralatan)) ?></div>
+
+  <div class="label" style="margin-top:8px">PROSEDUR KERJA</div>
+  <div class="box"><?= nl2br(htmlspecialchars($prosedur)) ?></div>
+
+  <div class="label" style="margin-top:8px">KESIMPULAN</div>
+  <div class="box"><?= nl2br(htmlspecialchars($kesimpulan)) ?></div>
+
+  <?php if($imgs): ?>
+    <div class="label" style="margin-top:8px">RAJAH / GAMBAR</div>
+    <div class="imgs">
+      <?php foreach($imgs as $p):
+        $src = $base . $p; ?>
+        <img src="<?= htmlspecialchars($src) ?>" alt="">
+      <?php endforeach; ?>
+    </div>
+  <?php endif; ?>
+</body>
+</html>
+<?php
+$html = ob_get_clean();
+
+// If Dompdf is available, render a real PDF
+$dompdfAutoload = __DIR__ . '/../vendor/autoload.php';
+if (file_exists($dompdfAutoload)) {
+  require_once $dompdfAutoload;
+  $opts = new Dompdf\Options();
+  $opts->set('isRemoteEnabled', true);
+  $opts->set('isHtml5ParserEnabled', true);
+  $dompdf = new Dompdf\Dompdf($opts);
+  $dompdf->loadHtml($html, 'UTF-8');
+  $dompdf->setPaper('A4', 'portrait');
+  $dompdf->render();
+  $dompdf->stream("daily_log_$id.pdf", ['Attachment'=>false]); // inline
+  exit;
+}
+
+// Fallback: show the print view HTML (user can Save as PDF)
+echo $html;

--- a/INTERNS/student/dashboard.php
+++ b/INTERNS/student/dashboard.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__.'/../app/auth.php';  require_role(['student']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+function table_exists(PDO $pdo, string $t): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name=? LIMIT 1");
+  $st->execute([$t]); return (bool)$st->fetchColumn();
+}
+function col_exists(PDO $pdo, string $t, string $c): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name=? AND column_name=? LIMIT 1");
+  $st->execute([$t,$c]); return (bool)$st->fetchColumn();
+}
+function scalar(PDO $pdo,string $sql,array $p=[]): int {
+  $st=$pdo->prepare($sql); $st->execute($p); return (int)$st->fetchColumn();
+}
+
+$uid = (int)($_SESSION['user']['id'] ?? 0);
+
+// support old schema names
+$dailyTable = table_exists($pdo,'daily_logs') ? 'daily_logs' : (table_exists($pdo,'logs') ? 'logs' : null);
+
+// counts for this student
+$counts = [
+  'daily'   => $dailyTable ? scalar($pdo, "SELECT COUNT(*) FROM `$dailyTable` WHERE user_id=?", [$uid]) : 0,
+  'weekly'  => table_exists($pdo,'weekly_reports') ? scalar($pdo, "SELECT COUNT(*) FROM weekly_reports WHERE user_id=?", [$uid]) : 0,
+  'leaves'  => table_exists($pdo,'leaves') ? scalar($pdo, "SELECT COUNT(*) FROM leaves WHERE user_id=?", [$uid]) : 0,
+  'pending' => (table_exists($pdo,'leaves') && col_exists($pdo,'leaves','status'))
+                ? scalar($pdo, "SELECT COUNT(*) FROM leaves WHERE user_id=? AND status='pending'", [$uid])
+                : 0,
+];
+
+include __DIR__.'/../app/header.php';
+?>
+<h2>Student Dashboard</h2>
+
+<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;margin-bottom:16px">
+  <div class="card" style="padding:14px;background:var(--card);border:1px solid var(--line);border-radius:10px">
+    <div>My daily logs</div>
+    <div style="font-size:28px;font-weight:700;margin:.25rem 0"><?= (int)$counts['daily'] ?></div>
+    <a class="btn" href="<?= url('/student/daily_new.php') ?>">New daily log</a>
+    <a style="margin-left:.5rem" href="<?= url('/student/daily_list.php') ?>">View all</a>
+  </div>
+  <div class="card" style="padding:14px;background:var(--card);border:1px solid var(--line);border-radius:10px">
+    <div>My weekly reports</div>
+    <div style="font-size:28px;font-weight:700;margin:.25rem 0"><?= (int)$counts['weekly'] ?></div>
+    <a class="btn" href="<?= url('/student/weekly_new.php') ?>">New weekly report</a>
+    <a style="margin-left:.5rem" href="<?= url('/student/weekly_list.php') ?>">View all</a>
+  </div>
+  <div class="card" style="padding:14px;background:var(--card);border:1px solid var(--line);border-radius:10px">
+    <div>My leave requests</div>
+    <div style="font-size:28px;font-weight:700;margin:.25rem 0">
+      <?= (int)$counts['leaves'] ?><?php if($counts['pending']): ?> <small>(<?= (int)$counts['pending'] ?> pending)</small><?php endif; ?>
+    </div>
+    <a class="btn" href="<?= url('/student/leave_new.php') ?>">Request leave</a>
+    <a style="margin-left:.5rem" href="<?= url('/student/leave_list.php') ?>">View all</a>
+  </div>
+</div>
+
+<h3>Quick links</h3>
+<ul>
+  <li><a href="<?= url('/student/daily_new.php') ?>">New Daily Log</a></li>
+  <li><a href="<?= url('/student/daily_list.php') ?>">My Daily Logs</a></li>
+  <li><a href="<?= url('/student/weekly_new.php') ?>">New Weekly Report</a></li>
+  <li><a href="<?= url('/student/weekly_list.php') ?>">My Weekly Reports</a></li>
+  <li><a href="<?= url('/student/leave_new.php') ?>">Request Leave</a></li>
+  <li><a href="<?= url('/student/leave_list.php') ?>">My Leave Requests</a></li>
+</ul>
+
+</main></body></html>

--- a/INTERNS/student/leave_list.php
+++ b/INTERNS/student/leave_list.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors','1'); ini_set('display_startup_errors','1'); error_reporting(E_ALL);
+
+require_once __DIR__ . '/../app/config.php';
+$config = (isset($config) && is_array($config)) ? $config : (is_array(@require __DIR__ . '/../app/config.php') ? require __DIR__ . '/../app/config.php' : []);
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/helpers.php';
+require_role(['student']);
+
+$me = (int)($_SESSION['user']['id'] ?? 0);
+
+function app_base(?array $cfg): string {
+  return rtrim(defined('APP_BASE') ? (string)APP_BASE : (string)($cfg['APP_BASE'] ?? ''), '/');
+}
+$APP_BASE = app_base($config);
+
+/* Filters */
+$q      = trim($_GET['q'] ?? '');
+$from   = trim($_GET['from'] ?? '');
+$to     = trim($_GET['to'] ?? '');
+$status = trim($_GET['status'] ?? '');
+
+$where = ["l.user_id = ?"]; $args = [$me];
+if ($q     !== '') { $where[]="l.reason LIKE ?"; $args[]="%$q%"; }
+if ($from  !== '') { $where[]="l.date_from >= ?"; $args[]=$from; }
+if ($to    !== '') { $where[]="l.date_to   <= ?"; $args[]=$to; }
+if ($status!== '') { $where[]="l.status = ?";     $args[]=$status; }
+$sqlWhere = 'WHERE '.implode(' AND ', $where);
+
+/* Query */
+$sql = "
+  SELECT l.id, l.date_from, l.date_to, l.reason, l.status
+  FROM leaves l
+  $sqlWhere
+  ORDER BY l.date_from DESC, l.id DESC
+  LIMIT 500
+";
+$st=$pdo->prepare($sql); $st->execute($args); $rows=$st->fetchAll(PDO::FETCH_ASSOC);
+
+/* CSV export */
+if (isset($_GET['export']) && $_GET['export'] === 'csv') {
+  header('Content-Type: text/csv');
+  header('Content-Disposition: attachment; filename="my_leaves.csv"');
+  $out = fopen('php://output', 'w');
+  fputcsv($out, ['From','To','Reason','Status']);
+  foreach ($rows as $r) {
+    fputcsv($out, [$r['date_from'], $r['date_to'], $r['reason'], $r['status']]);
+  }
+  exit;
+}
+
+$statuses = ['pending','approved','rejected'];
+$title = 'Student · My Leave Requests';
+?>
+<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title><?= h($title) ?></title>
+<link rel="stylesheet" href="<?= $APP_BASE ?>/assets/style.css">
+</head><body>
+<?php include __DIR__.'/../app/header.php'; ?>
+<div class="container">
+  <h1>My Leave Requests</h1>
+
+  <form method="get" class="filters" style="display:flex;gap:.5rem;flex-wrap:wrap;margin:.75rem 0 1rem">
+    <input name="q" value="<?= h($q) ?>" placeholder="Search reason">
+    <input type="date" name="from" value="<?= h($from) ?>">
+    <input type="date" name="to"   value="<?= h($to) ?>">
+    <select name="status">
+      <option value="">Any status</option>
+      <?php foreach ($statuses as $s): ?>
+        <option value="<?= $s ?>" <?= $status===$s?'selected':'' ?>><?= ucfirst($s) ?></option>
+      <?php endforeach; ?>
+    </select>
+    <button class="btn">Filter</button>
+    <button class="btn" name="export" value="csv">Export CSV</button>
+  </form>
+
+  <table class="table">
+    <thead><tr><th>Dates</th><th>Reason</th><th>Status</th></tr></thead>
+    <tbody>
+      <?php foreach ($rows as $r): ?>
+        <tr>
+          <td><?= h($r['date_from']) ?> → <?= h($r['date_to']) ?></td>
+          <td><?= h(mb_strimwidth((string)$r['reason'], 0, 160, '…')) ?></td>
+          <td><span class="status <?= h(strtolower($r['status'])) ?>"><?= h($r['status']) ?></span></td>
+        </tr>
+      <?php endforeach; if(!$rows): ?>
+        <tr><td colspan="3">No results.</td></tr>
+      <?php endif; ?>
+    </tbody>
+  </table>
+</div>
+</body></html>

--- a/INTERNS/student/leave_new.php
+++ b/INTERNS/student/leave_new.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../app/init.php';
+require_once __DIR__ . '/../app/db.php';
+require_role(['student']);
+
+$uid = (int)($_SESSION['user']['id'] ?? 0);
+$ok = false; $msg = ''; $errors = [];
+
+// Ensure base table exists (safe if it does)
+$pdo->exec("CREATE TABLE IF NOT EXISTS leaves (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  leave_date DATE,
+  days INT DEFAULT 1,
+  reason TEXT,
+  status ENUM('pending','approved','rejected') DEFAULT 'pending',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB");
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $leave_date = trim($_POST['leave_date'] ?? '');
+  $days       = (int)($_POST['days'] ?? 1);
+  $reason     = trim($_POST['reason'] ?? '');
+
+  if ($leave_date === '') $errors['leave_date'] = 'Leave date required.';
+  if ($days <= 0)         $errors['days'] = 'Days must be positive.';
+
+  if (!$errors) {
+    $cols = ['user_id','leave_date','days','reason','status'];
+    $vals = [$uid, $leave_date, $days, $reason, 'pending'];
+    $pdo->prepare("INSERT INTO `leaves` (".implode(',',$cols).") VALUES (?,?,?,?,?)")->execute($vals);
+
+    /* PATCH_LEAVE_FILES */
+    $leaveId = (int)$pdo->lastInsertId();
+    $upDir = __DIR__ . '/../uploads/leaves';
+    if (!is_dir($upDir)) @mkdir($upDir, 0777, true);
+
+    if (!empty($_FILES['evidence']) && is_array($_FILES['evidence']['name'])) {
+      // Ensure file table
+      $pdo->exec("CREATE TABLE IF NOT EXISTS leaves_files (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        leave_id INT NOT NULL,
+        path VARCHAR(255) NOT NULL,
+        original_name VARCHAR(255),
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (leave_id) REFERENCES leaves(id) ON DELETE CASCADE
+      ) ENGINE=InnoDB");
+
+      for ($i=0; $i<count($_FILES['evidence']['name']); $i++) {
+        if (empty($_FILES['evidence']['name'][$i])) continue;
+        $tmp  = $_FILES['evidence']['tmp_name'][$i] ?? '';
+        $name = basename($_FILES['evidence']['name'][$i] ?? '');
+        if (!$tmp) continue;
+        $safe = preg_replace('/[^a-zA-Z0-9._-]/','_', $name);
+        $dest = $upDir.'/'.time().'_'.$safe;
+        if (is_uploaded_file($tmp) && move_uploaded_file($tmp, $dest)) {
+          $pdo->prepare("INSERT INTO leaves_files (leave_id,path,original_name) VALUES (?,?,?)")
+              ->execute([$leaveId, $dest, $name]);
+        }
+      }
+    }
+
+    $ok = true;
+    $msg = 'Leave request submitted.';
+  }
+}
+include __DIR__ . '/../app/header.php';
+?>
+<main class="container">
+  <h1>New Leave Application</h1>
+
+  <?php if ($ok): ?><div class="ok"><?= h($msg) ?></div><?php endif; ?>
+  <?php if ($errors): ?>
+    <div class="error-list"><?php foreach ($errors as $e): ?><div><?= h($e) ?></div><?php endforeach; ?></div>
+  <?php endif; ?>
+
+  <form method="post" enctype="multipart/form-data">
+    <div class="grid">
+      <label>Leave Date
+        <input type="date" name="leave_date" value="<?= h($_POST['leave_date'] ?? '') ?>" required>
+      </label>
+      <label>Days
+        <input type="number" name="days" min="1" value="<?= h($_POST['days'] ?? '1') ?>" required>
+      </label>
+    </div>
+
+    <label>Upload evidence (images/files)
+      <input type="file" name="evidence[]" multiple>
+    </label>
+
+    <label>Reason
+      <textarea name="reason" rows="4"><?= h($_POST['reason'] ?? '') ?></textarea>
+    </label>
+
+    <button class="btn">Submit</button>
+    <a class="btn ghost" href="<?= url('/student/leaves_list.php') ?>">Back</a>
+  </form>
+</main>
+</body></html>

--- a/INTERNS/student/leave_pdf.php
+++ b/INTERNS/student/leave_pdf.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__.'/../app/auth.php';  require_role(['student']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+function col_exists(PDO $pdo, string $t, string $c): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name=? AND column_name=? LIMIT 1");
+  $st->execute([$t,$c]); return (bool)$st->fetchColumn();
+}
+$id=(int)($_GET['id']??0); $uid=(int)$_SESSION['user']['id'];
+$tbl='leaves';
+$dateCol = col_exists($pdo,$tbl,'leave_date') ? 'leave_date' : (col_exists($pdo,$tbl,'date') ? 'date' : 'created_at');
+$daysCol = col_exists($pdo,$tbl,'days') ? 'days' : (col_exists($pdo,$tbl,'num_days') ? 'num_days' : (col_exists($pdo,$tbl,'no_of_days') ? 'no_of_days' : null));
+
+$st=$pdo->prepare("SELECT * FROM `$tbl` WHERE id=? AND user_id=? LIMIT 1");
+$st->execute([$id,$uid]); $row=$st->fetch(); if(!$row){ http_response_code(404); echo 'Not found'; exit; }
+
+$base = rtrim((require __DIR__.'/../app/config.php')['APP_BASE'],'/');
+
+ob_start(); ?>
+<!doctype html><html><head><meta charset="utf-8"><title>Leave Request</title>
+<style>
+ body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial;margin:28px;font-size:13px;color:#111}
+ h1{font-size:20px;margin:0 0 8px}
+ .label{font-weight:700;margin-top:8px}.box{border:1px solid #bbb;border-radius:6px;padding:8px;min-height:38px}
+ .row{display:flex;gap:12px}.col{flex:1} .badge{background:#eee;border-radius:999px;padding:2px 8px;font-size:12px;display:inline-block}
+ @media print{.noprint{display:none}}
+</style></head><body>
+<div class="noprint" style="text-align:right;margin-bottom:6px"><button onclick="window.print()">Print / Save as PDF</button></div>
+<h1>Leave Request</h1>
+<?php if(isset($row['status'])): ?><div class="badge">Status: <?= h($row['status']) ?></div><?php endif; ?>
+
+<div class="row" style="margin-top:8px">
+  <div class="col"><div class="label">Date</div><div class="box"><?= h($row[$dateCol]??'') ?></div></div>
+  <?php if($daysCol): ?><div class="col"><div class="label">No. of days</div><div class="box"><?= h($row[$daysCol]??'') ?></div></div><?php endif; ?>
+</div>
+
+<div class="label">Reason</div><div class="box"><?= nl2br(h($row['reason']??'')) ?></div>
+
+<?php if(!empty($row['supervisor_comment']) || !empty($row['supervisor_signed_at']) || !empty($row['supervisor_signature_path'])): ?>
+  <div class="label">Supervisor section</div>
+  <div class="box">
+    <?php if(!empty($row['supervisor_comment'])): ?><div><strong>Comment:</strong> <?= nl2br(h($row['supervisor_comment'])) ?></div><?php endif; ?>
+    <?php if(!empty($row['supervisor_signed_at'])): ?><div><strong>Signed at:</strong> <?= h($row['supervisor_signed_at']) ?></div><?php endif; ?>
+    <?php if(!empty($row['supervisor_signature_path'])): ?><div style="margin-top:6px"><img src="<?= h($base.$row['supervisor_signature_path']) ?>" style="height:60px"></div><?php endif; ?>
+  </div>
+<?php endif; ?>
+</body></html>
+<?php
+$html=ob_get_clean();
+$autoload=__DIR__.'/../vendor/autoload.php';
+if(file_exists($autoload)){
+  require_once $autoload;
+  $opt=new Dompdf\Options(); $opt->set('isRemoteEnabled',true); $opt->set('isHtml5ParserEnabled',true);
+  $pdf=new Dompdf\Dompdf($opt); $pdf->loadHtml($html,'UTF-8'); $pdf->setPaper('A4','portrait'); $pdf->render();
+  $pdf->stream("leave_$id.pdf",['Attachment'=>false]); exit;
+}
+echo $html;

--- a/INTERNS/student/leaves_book_pdf.php
+++ b/INTERNS/student/leaves_book_pdf.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__.'/../app/auth.php';  require_role(['student']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+function col_exists(PDO $pdo, string $t, string $c): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name=? AND column_name=? LIMIT 1");
+  $st->execute([$t,$c]); return (bool)$st->fetchColumn();
+}
+$tbl='leaves'; $uid=(int)$_SESSION['user']['id'];
+$dateCol = col_exists($pdo,$tbl,'leave_date') ? 'leave_date' : (col_exists($pdo,$tbl,'date') ? 'date' : 'created_at');
+$daysCol = col_exists($pdo,$tbl,'days') ? 'days' : (col_exists($pdo,$tbl,'num_days') ? 'num_days' : (col_exists($pdo,$tbl,'no_of_days') ? 'no_of_days' : null));
+
+$st=$pdo->prepare("SELECT * FROM `$tbl` WHERE user_id=? ORDER BY `$dateCol` ASC, id ASC"); $st->execute([$uid]); $rows=$st->fetchAll();
+$base=rtrim((require __DIR__.'/../app/config.php')['APP_BASE'],'/');
+
+ob_start(); ?>
+<!doctype html><html><head><meta charset="utf-8"><title>Student Leave Record</title>
+<style>
+ body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial;margin:28px;font-size:12px;color:#111}
+ h1{font-size:18px;text-align:center;margin:0 0 12px}
+ table{width:100%;border-collapse:collapse}
+ th,td{border:1px solid #222;padding:6px 8px;vertical-align:top}
+ th{text-transform:uppercase}
+ .sig{height:28px}
+ @media print{.noprint{display:none}}
+</style></head><body>
+<div class="noprint" style="text-align:right;margin-bottom:6px"><button onclick="window.print()">Print / Save as PDF</button></div>
+<h1>STUDENT LEAVE RECORD</h1>
+<table>
+  <tr>
+    <th style="width:40px">No.</th>
+    <th style="width:120px">Date</th>
+    <th>Reason</th>
+    <th style="width:80px">No. of days</th>
+    <th style="width:160px">Officer signature</th>
+  </tr>
+  <?php $i=1; foreach($rows as $r): ?>
+    <tr>
+      <td><?= $i++ ?></td>
+      <td><?= h($r[$dateCol] ?? '') ?></td>
+      <td><?= nl2br(h($r['reason'] ?? '')) ?></td>
+      <td><?= $daysCol ? h($r[$daysCol] ?? '') : '' ?></td>
+      <td>
+        <?php if(!empty($r['supervisor_signature_path'])): ?>
+          <img class="sig" src="<?= h($base.$r['supervisor_signature_path']) ?>">
+        <?php else: ?>—<?php endif; ?>
+      </td>
+    </tr>
+  <?php endforeach; ?>
+</table>
+</body></html>
+<?php
+$html=ob_get_clean();
+$autoload=__DIR__.'/../vendor/autoload.php';
+if(file_exists($autoload)){
+  require_once $autoload;
+  $opt=new Dompdf\Options(); $opt->set('isRemoteEnabled',true); $opt->set('isHtml5ParserEnabled',true);
+  $pdf=new Dompdf\Dompdf($opt); $pdf->loadHtml($html,'UTF-8'); $pdf->setPaper('A4','portrait'); $pdf->render();
+  $pdf->stream("leave_record.pdf",['Attachment'=>false]); exit;
+}
+echo $html;

--- a/INTERNS/student/weekly_list.php
+++ b/INTERNS/student/weekly_list.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors','1'); ini_set('display_startup_errors','1'); error_reporting(E_ALL);
+
+require_once __DIR__ . '/../app/config.php';
+$config = (isset($config) && is_array($config)) ? $config : (is_array(@require __DIR__ . '/../app/config.php') ? require __DIR__ . '/../app/config.php' : []);
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/helpers.php';
+require_role(['student']);
+
+$me = (int)($_SESSION['user']['id'] ?? 0);
+
+function app_base(?array $cfg): string {
+  return rtrim(defined('APP_BASE') ? (string)APP_BASE : (string)($cfg['APP_BASE'] ?? ''), '/');
+}
+$APP_BASE = app_base($config);
+
+/* Filters */
+$q    = trim($_GET['q'] ?? '');
+$from = trim($_GET['from'] ?? '');
+$to   = trim($_GET['to'] ?? '');
+$dateExpr = "COALESCE(w.week_start, w.report_date, w.created_at)";
+
+$where = ["w.user_id = ?"]; $args = [$me];
+if ($q   !== '') { $where[]="(w.activities_summary LIKE ? OR w.activity_summary LIKE ? OR w.highlights LIKE ?)"; $args[]="%$q%"; $args[]="%$q%"; $args[]="%$q%"; }
+if ($from!== '') { $where[]="$dateExpr >= ?"; $args[]=$from; }
+if ($to  !== '') { $where[]="$dateExpr <= ?"; $args[]=$to; }
+$sqlWhere = 'WHERE '.implode(' AND ', $where);
+
+/* Query */
+$sql = "
+  SELECT
+    w.id, w.week_no, w.week_start, w.report_date, w.created_at, w.status,
+    COALESCE(w.activities_summary, w.activity_summary, w.highlights, '') AS summary,
+    $dateExpr AS week_val
+  FROM weekly_reports w
+  $sqlWhere
+  ORDER BY $dateExpr DESC, w.id DESC
+  LIMIT 500
+";
+$st=$pdo->prepare($sql); $st->execute($args); $rows=$st->fetchAll(PDO::FETCH_ASSOC);
+
+/* CSV export */
+if (isset($_GET['export']) && $_GET['export'] === 'csv') {
+  header('Content-Type: text/csv');
+  header('Content-Disposition: attachment; filename="my_weekly_reports.csv"');
+  $out = fopen('php://output', 'w');
+  fputcsv($out, ['Week','Week No','Summary','Status']);
+  foreach ($rows as $r) {
+    fputcsv($out, [$r['week_val'], $r['week_no'], $r['summary'], $r['status']]);
+  }
+  exit;
+}
+
+$title = 'Student · My Weekly Reports';
+?>
+<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title><?= h($title) ?></title>
+<link rel="stylesheet" href="<?= $APP_BASE ?>/assets/style.css">
+</head><body>
+<?php include __DIR__.'/../app/header.php'; ?>
+<div class="container">
+  <h1>My Weekly Reports</h1>
+
+  <form method="get" class="filters" style="display:flex;gap:.5rem;flex-wrap:wrap;margin:.75rem 0 1rem">
+    <input name="q" value="<?= h($q) ?>" placeholder="Search summary">
+    <input type="date" name="from" value="<?= h($from) ?>">
+    <input type="date" name="to"   value="<?= h($to) ?>">
+    <button class="btn">Filter</button>
+    <button class="btn" name="export" value="csv">Export CSV</button>
+  </form>
+
+  <table class="table">
+    <thead><tr><th>Week</th><th>Week No</th><th>Summary</th><th>Status</th></tr></thead>
+    <tbody>
+      <?php foreach ($rows as $r): ?>
+        <tr>
+          <td><?= h($r['week_val']) ?></td>
+          <td><?= h((string)$r['week_no']) ?></td>
+          <td><?= h(mb_strimwidth((string)$r['summary'], 0, 160, '…')) ?></td>
+          <td><span class="status <?= h(strtolower($r['status'])) ?>"><?= h($r['status']) ?></span></td>
+        </tr>
+      <?php endforeach; if(!$rows): ?>
+        <tr><td colspan="4">No results.</td></tr>
+      <?php endif; ?>
+    </tbody>
+  </table>
+</div>
+</body></html>

--- a/INTERNS/student/weekly_new.php
+++ b/INTERNS/student/weekly_new.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__.'/../app/auth.php';  require_role(['student']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+function col_exists(PDO $pdo, string $t, string $c): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name=? AND column_name=? LIMIT 1");
+  $st->execute([$t,$c]); return (bool)$st->fetchColumn();
+}
+function table_exists(PDO $pdo, string $t): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name=? LIMIT 1");
+  $st->execute([$t]); return (bool)$st->fetchColumn();
+}
+
+$tbl = 'weekly_reports';
+$imgTable = table_exists($pdo,'weekly_images') ? 'weekly_images' : 'weekly_images';
+$uid = (int)($_SESSION['user']['id'] ?? 0);
+
+$msg=''; $err='';
+if($_SERVER['REQUEST_METHOD']==='POST'){
+  $report_date = $_POST['report_date'] ?? '';
+  $week_no     = (int)($_POST['week_no'] ?? 0);
+  $activity    = trim($_POST['activity_summary'] ?? '');
+  $skills      = trim($_POST['skills_gained'] ?? '');
+  $impact      = trim($_POST['impact_on_student'] ?? '');
+
+  if(!$report_date || !$week_no || !$activity || !$skills || !$impact){
+    $err = 'Please fill in Date, Week, Activity Summary, Skills Gained and Impact.';
+  }
+
+  if(!$err){
+    try{
+      $base = [
+        'user_id'          => $uid,
+        'report_date'      => $report_date,
+        'week_no'          => $week_no,
+        'activity_summary' => $activity,
+        'skills_gained'    => $skills,
+        'impact_on_student'=> $impact,
+        'status'           => 'submitted',
+      ];
+      // backward-compat mappings if your columns differ
+      if(col_exists($pdo,$tbl,'date'))     $base['date'] = $report_date;
+      if(col_exists($pdo,$tbl,'week'))     $base['week'] = $week_no;
+      if(col_exists($pdo,$tbl,'summary'))  $base['summary'] = $activity;
+      if(col_exists($pdo,$tbl,'knowledge'))$base['knowledge'] = $skills;
+      if(col_exists($pdo,$tbl,'impact'))   $base['impact'] = $impact;
+
+      $payload=[];
+      foreach($base as $k=>$v) if(col_exists($pdo,$tbl,$k)) $payload[$k]=$v;
+
+      foreach (['user_id','report_date'] as $must)
+        if(!col_exists($pdo,$tbl,$must)) throw new RuntimeException("Missing column `$must` in weekly_reports.");
+
+      $cols=implode(',',array_map(fn($c)=>"`$c`",array_keys($payload)));
+      $qst =implode(',',array_fill(0,count($payload),'?'));
+      $st=$pdo->prepare("INSERT INTO `$tbl` ($cols) VALUES ($qst)");
+      $st->execute(array_values($payload));
+      $wid=(int)$pdo->lastInsertId();
+
+      // images
+      if(!empty($_FILES['images']['name'][0])){
+        $dir = __DIR__.'/../uploads/weekly';
+        if(!is_dir($dir)) @mkdir($dir,0775,true);
+        $fk = col_exists($pdo,$imgTable,'weekly_id') ? 'weekly_id' : 'weekly_id';
+        $ist=$pdo->prepare("INSERT INTO `$imgTable` (`$fk`,`path`) VALUES (?,?)");
+
+        $files=$_FILES['images']; $fi = new finfo(FILEINFO_MIME_TYPE);
+        for($i=0;$i<count($files['name']);$i++){
+          if($files['error'][$i]!==UPLOAD_ERR_OK) continue;
+          $tmp=$files['tmp_name'][$i]; $mime=$fi->file($tmp);
+          if(strpos($mime,'image/')!==0) continue;
+          if(filesize($tmp)>5*1024*1024) continue;
+
+          $ext=strtolower(pathinfo($files['name'][$i],PATHINFO_EXTENSION));
+          $safe=preg_replace('/[^a-zA-Z0-9._-]/','_',pathinfo($files['name'][$i],PATHINFO_FILENAME));
+          $name=sprintf('w_%d_%s_%s.%s',$uid,date('YmdHis'),$safe,$ext);
+          $dest=$dir.'/'.$name;
+          if(move_uploaded_file($tmp,$dest)){
+            $ist->execute([$wid, '/uploads/weekly/'.$name]);
+          }
+        }
+      }
+
+      $msg='Weekly reflection submitted.';
+    }catch(Throwable $e){ $err='Save failed: '.$e->getMessage(); }
+  }
+}
+
+include __DIR__.'/../app/header.php';
+?>
+<h2>Weekly Reflection</h2>
+<?php if($msg):?><p class="ok"><?= h($msg) ?></p><?php endif; ?>
+<?php if($err):?><p class="error"><?= h($err) ?></p><?php endif; ?>
+
+<form method="post" enctype="multipart/form-data">
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
+    <label>Date <input type="date" name="report_date" required></label>
+    <label>Week <input type="number" name="week_no" min="1" step="1" required></label>
+  </div>
+  <fieldset style="margin-top:12px;border:1px solid var(--line);border-radius:.5rem">
+    <legend>To be completed by Student</legend>
+    <label>Weekly activities carried out (brief)
+      <textarea name="activity_summary" rows="6" required></textarea></label>
+    <label>Knowledge/skills acquired (during the week)
+      <textarea name="skills_gained" rows="6" required></textarea></label>
+    <label>Impact and effects on the student
+      <textarea name="impact_on_student" rows="6" required></textarea></label>
+  </fieldset>
+
+  <label style="margin-top:10px">Images (you may select multiple)
+    <input type="file" name="images[]" accept="image/*" multiple>
+  </label>
+
+  <p style="opacity:.8;margin:.5rem 0 1rem"><em>The section below is for the Industry Supervisor and is not editable here.</em></p>
+  <button class="btn">Submit</button>
+</form>
+
+<p><a href="<?= url('/student/weekly_list.php') ?>">My weekly reflections</a></p>
+<p><a href="<?= url('/student/dashboard.php') ?>">Back to dashboard</a></p>
+</main></body></html>

--- a/INTERNS/student/weekly_pdf.php
+++ b/INTERNS/student/weekly_pdf.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__.'/../app/auth.php';  require_role(['student']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+function col_exists(PDO $pdo, string $t, string $c): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name=? AND column_name=? LIMIT 1");
+  $st->execute([$t,$c]); return (bool)$st->fetchColumn();
+}
+
+$id  = (int)($_GET['id'] ?? 0);
+$uid = (int)($_SESSION['user']['id'] ?? 0);
+$tbl = 'weekly_reports';
+$imgTbl = 'weekly_images';
+
+$dateCol = col_exists($pdo,$tbl,'report_date') ? 'report_date' : (col_exists($pdo,$tbl,'date') ? 'date' : 'created_at');
+$weekCol = col_exists($pdo,$tbl,'week_no') ? 'week_no' : (col_exists($pdo,$tbl,'week') ? 'week' : null);
+
+$st=$pdo->prepare("SELECT * FROM `$tbl` WHERE id=? AND user_id=? LIMIT 1");
+$st->execute([$id,$uid]);
+$w=$st->fetch(); if(!$w){ http_response_code(404); echo 'Not found'; exit; }
+
+$fk = col_exists($pdo,$imgTbl,'weekly_id') ? 'weekly_id' : 'weekly_id';
+$si=$pdo->prepare("SELECT path FROM `$imgTbl` WHERE `$fk`=? ORDER BY id");
+$si->execute([$id]); $imgs=$si->fetchAll(PDO::FETCH_COLUMN);
+
+$base = rtrim((require __DIR__.'/../app/config.php')['APP_BASE'],'/');
+
+ob_start(); ?>
+<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Weekly Reflection</title>
+<style>
+ body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial;margin:28px;font-size:13px;color:#111}
+ h1{font-size:20px;margin:0 0 8px} .label{font-weight:700;margin-top:8px}
+ .box{border:1px solid #bbb;border-radius:6px;padding:8px;min-height:44px}
+ .row{display:flex;gap:12px} .col{flex:1}
+ .imgs{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
+ .imgs img{height:120px;object-fit:cover;border:1px solid #bbb;border-radius:4px}
+ .badge{display:inline-block;padding:2px 8px;border-radius:999px;background:#eee;font-size:12px}
+ @media print{.noprint{display:none}}
+</style>
+</head>
+<body>
+  <div class="noprint" style="text-align:right;margin-bottom:6px">
+    <button onclick="window.print()">Print / Save as PDF</button>
+  </div>
+
+  <h1>Weekly Reflection</h1>
+  <div><?php if(isset($w['status'])): ?><span class="badge">Status: <?= htmlspecialchars($w['status']) ?></span><?php endif; ?></div>
+
+  <div class="row" style="margin-top:8px">
+    <div class="col"><div class="label">Date</div><div class="box"><?= htmlspecialchars($w[$dateCol] ?? '') ?></div></div>
+    <?php if($weekCol): ?><div class="col"><div class="label">Week</div><div class="box"><?= htmlspecialchars($w[$weekCol] ?? '') ?></div></div><?php endif; ?>
+  </div>
+
+  <?php if(isset($w['activity_summary'])): ?><div class="label">Weekly activities carried out (brief)</div>
+  <div class="box"><?= nl2br(htmlspecialchars($w['activity_summary'])) ?></div><?php endif; ?>
+
+  <?php if(isset($w['skills_gained'])): ?><div class="label">Knowledge/skills acquired (during the week)</div>
+  <div class="box"><?= nl2br(htmlspecialchars($w['skills_gained'])) ?></div><?php endif; ?>
+
+  <?php if(isset($w['impact_on_student'])): ?><div class="label">Impact and effects on the student</div>
+  <div class="box"><?= nl2br(htmlspecialchars($w['impact_on_student'])) ?></div><?php endif; ?>
+
+  <?php if($imgs): ?><div class="label">Images</div>
+    <div class="imgs">
+      <?php foreach($imgs as $p): ?><img src="<?= htmlspecialchars($base.$p) ?>" alt=""><?php endforeach; ?>
+    </div>
+  <?php endif; ?>
+
+  <?php if(!empty($w['supervisor_comment']) || !empty($w['supervisor_signature_path'])): ?>
+    <div class="label">Supervisor section</div>
+    <div class="box">
+      <?php if(!empty($w['supervisor_comment'])): ?>
+        <div><strong>Comment: </strong><?= nl2br(htmlspecialchars($w['supervisor_comment'])) ?></div>
+      <?php endif; ?>
+      <?php if(!empty($w['supervisor_signed_at'])): ?>
+        <div><strong>Signed at: </strong><?= htmlspecialchars($w['supervisor_signed_at']) ?></div>
+      <?php endif; ?>
+      <?php if(!empty($w['supervisor_signature_path'])): ?>
+        <div style="margin-top:6px"><img src="<?= htmlspecialchars($base.$w['supervisor_signature_path']) ?>" style="height:60px"></div>
+      <?php endif; ?>
+    </div>
+  <?php endif; ?>
+</body>
+</html>
+<?php
+$html = ob_get_clean();
+$autoload = __DIR__.'/../vendor/autoload.php';
+if(file_exists($autoload)){
+  require_once $autoload;
+  $opt=new Dompdf\Options(); $opt->set('isRemoteEnabled',true); $opt->set('isHtml5ParserEnabled',true);
+  $pdf=new Dompdf\Dompdf($opt); $pdf->loadHtml($html,'UTF-8'); $pdf->setPaper('A4','portrait'); $pdf->render();
+  $pdf->stream("weekly_$id.pdf",['Attachment'=>false]); exit;
+}
+echo $html;

--- a/INTERNS/supervisor/assignments.php
+++ b/INTERNS/supervisor/assignments.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__.'/../app/init.php';
+require_once __DIR__.'/../app/db.php';
+require_role(['supervisor']);
+
+$me = (int)($_SESSION['user']['id'] ?? 0);
+
+// Ensure table exists
+$pdo->exec("CREATE TABLE IF NOT EXISTS student_assignments (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  student_id INT NOT NULL,
+  lecturer_id INT,
+  supervisor_id INT,
+  status ENUM('pending','approved','rejected') NOT NULL DEFAULT 'pending',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (student_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (lecturer_id) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (supervisor_id) REFERENCES users(id) ON DELETE SET NULL
+) ENGINE=InnoDB");
+
+// Action
+if (isset($_POST['act'], $_POST['id'])) {
+  $id = (int)$_POST['id'];
+  $act = $_POST['act']==='approve' ? 'approved' : 'rejected';
+  $st = $pdo->prepare("UPDATE student_assignments SET status=? WHERE id=? AND supervisor_id=?");
+  $st->execute([$act, $id, $me]);
+  header('Location: '.url('/supervisor/assignments.php')); exit;
+}
+
+// Pending list
+$rows = $pdo->prepare("SELECT sa.id, u.name, u.email
+                       FROM student_assignments sa
+                       JOIN users u ON u.id=sa.student_id
+                       WHERE sa.supervisor_id=? AND sa.status='pending'
+                       ORDER BY sa.created_at DESC");
+$rows->execute([$me]);
+$rows = $rows->fetchAll(PDO::FETCH_ASSOC);
+
+include __DIR__.'/../app/header.php';
+?>
+<main class="container">
+  <h2>Pending Assignment Requests</h2>
+  <div class="card">
+    <table class="table">
+      <thead><tr><th>Student</th><th>Email</th><th>Action</th></tr></thead>
+      <tbody>
+        <?php foreach ($rows as $r): ?>
+          <tr>
+            <td><?= h($r['name']) ?></td>
+            <td><?= h($r['email']) ?></td>
+            <td>
+              <form method="post" style="display:inline">
+                <input type="hidden" name="id" value="<?= (int)$r['id'] ?>">
+                <button class="btn small" name="act" value="approve">Approve</button>
+                <button class="btn small" name="act" value="reject">Reject</button>
+              </form>
+            </td>
+          </tr>
+        <?php endforeach; if (!$rows): ?>
+          <tr><td colspan="3">No pending requests.</td></tr>
+        <?php endif; ?>
+      </tbody>
+    </table>
+  </div>
+  <p style="margin-top:14px"><a class="btn ghost" href="<?= url('/supervisor/dashboard.php') ?>">Back</a></p>
+</main>
+</body></html>

--- a/INTERNS/supervisor/daily_list.php
+++ b/INTERNS/supervisor/daily_list.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors','1'); ini_set('display_startup_errors','1'); error_reporting(E_ALL);
+
+require_once __DIR__ . '/../app/config.php';
+$config = (isset($config) && is_array($config)) ? $config : (is_array(@require __DIR__ . '/../app/config.php') ? require __DIR__ . '/../app/config.php' : []);
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/helpers.php';
+require_role(['supervisor']);
+
+$me = (int)($_SESSION['user']['id'] ?? 0);
+function app_base(?array $cfg): string { return rtrim(defined('APP_BASE') ? (string)APP_BASE : (string)($cfg['APP_BASE']??''), '/'); }
+$APP_BASE = app_base($config);
+
+function sa_cols(PDO $pdo): array {
+  $have=function(array $c) use($pdo){$in=implode(',',array_fill(0,count($c),'?'));$st=$pdo->prepare("SELECT COUNT(*) FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name='student_assignments' AND column_name IN ($in)");$st->execute($c);return (int)$st->fetchColumn()===count($c);};
+  if ($have(['student_user_id','supervisor_user_id'])) return ['student'=>'student_user_id','reviewer'=>'supervisor_user_id'];
+  if ($have(['student_id','supervisor_id']))           return ['student'=>'student_id','reviewer'=>'supervisor_id'];
+  return ['student'=>'student_user_id','reviewer'=>'supervisor_user_id'];
+}
+$sa = sa_cols($pdo);
+
+$q=trim($_GET['q']??''); $from=trim($_GET['from']??''); $to=trim($_GET['to']??'');
+$where=["sa.`{$sa['reviewer']}`=?"]; $args=[$me];
+if($q!==''){ $where[]="(u.name LIKE ? OR u.email LIKE ?)"; $args[]="%$q%"; $args[]="%$q%"; }
+if($from!==''){ $where[]="d.log_date >= ?"; $args[]=$from; }
+if($to!==''){ $where[]="d.log_date <= ?"; $args[]=$to; }
+$sqlWhere='WHERE '.implode(' AND ',$where);
+
+$sql="
+  SELECT d.id,d.user_id,d.log_date,d.activity,d.status,u.name,u.email
+  FROM daily_logs d
+  JOIN users u ON u.id=d.user_id
+  JOIN student_assignments sa ON sa.`{$sa['student']}`=u.id
+  $sqlWhere
+  ORDER BY d.log_date DESC,d.id DESC
+  LIMIT 200";
+$st=$pdo->prepare($sql); $st->execute($args); $rows=$st->fetchAll(PDO::FETCH_ASSOC);
+
+$title='Supervisor · Daily Logs';
+?>
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title><?= h($title) ?></title>
+<link rel="stylesheet" href="<?= $APP_BASE ?>/assets/style.css">
+</head><body>
+<?php include __DIR__.'/../app/header.php'; ?>
+<div class="container">
+  <h1>My Students · Daily Logs</h1>
+  <form method="get" class="filters" style="display:flex;gap:.5rem;flex-wrap:wrap;margin:.75rem 0 1rem">
+    <input name="q" value="<?= h($q) ?>" placeholder="Search student">
+    <input type="date" name="from" value="<?= h($from) ?>">
+    <input type="date" name="to" value="<?= h($to) ?>">
+    <button class="btn">Filter</button>
+  </form>
+  <table class="table">
+  <thead>
+    <tr><th>Date</th><th>Student</th><th>Activity</th><th>Status</th><th>Actions</th></tr>
+  </thead>
+  <tbody>
+    <?php foreach($rows as $r): ?>
+      <tr>
+        <td><?= h($r['log_date']) ?></td>
+        <td><?= h($r['name']) ?> <small>(<?= h($r['email']) ?>)</small></td>
+        <td><?= h($r['activity']) ?></td>
+        <td><span class="status <?= h(strtolower($r['status'])) ?>"><?= h($r['status']) ?></span></td>
+
+        <td>
+          <a class="btn small" href="<?= $APP_BASE ?>/supervisor/verify_daily.php?id=<?= (int)$r['id'] ?>">View / Verify</a>
+        </td>
+      </tr>
+    <?php endforeach; if(!$rows): ?>
+      <tr><td colspan="5">No results.</td></tr>
+    <?php endif; ?>
+  </tbody>
+</table>
+
+</div>
+</body></html>

--- a/INTERNS/supervisor/dashboard.php
+++ b/INTERNS/supervisor/dashboard.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../app/init.php';
+require_once __DIR__ . '/../app/db.php';
+require_role(['supervisor']);
+
+include __DIR__ . '/../app/header.php';
+?>
+<main class="container">
+  <h1>Supervisor Dashboard</h1>
+
+  <div class="cards">
+    <div class="card">
+      <h3>Welcome</h3>
+      <p>Here you can manage your assigned students and review submissions.</p>
+      <a class="btn" href="<?= url('/supervisor/assignments.php') ?>">Approve Student Assignments</a>
+    </div>
+  </div>
+
+</main>
+</body></html>

--- a/INTERNS/supervisor/leaves_list.php
+++ b/INTERNS/supervisor/leaves_list.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors','1'); ini_set('display_startup_errors','1'); error_reporting(E_ALL);
+
+require_once __DIR__ . '/../app/config.php';
+$config = (isset($config) && is_array($config)) ? $config : (is_array(@require __DIR__ . '/../app/config.php') ? require __DIR__ . '/../app/config.php' : []);
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/helpers.php';
+require_role(['supervisor']);
+
+$me = (int)($_SESSION['user']['id'] ?? 0);
+function app_base(?array $cfg): string { return rtrim(defined('APP_BASE') ? (string)APP_BASE : (string)($cfg['APP_BASE']??''), '/'); }
+$APP_BASE = app_base($config);
+
+function sa_cols(PDO $pdo): array {
+  $have=function(array $c) use($pdo){$in=implode(',',array_fill(0,count($c),'?'));$st=$pdo->prepare("SELECT COUNT(*) FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name='student_assignments' AND column_name IN ($in)");$st->execute($c);return (int)$st->fetchColumn()===count($c);};
+  if ($have(['student_user_id','supervisor_user_id'])) return ['student'=>'student_user_id','reviewer'=>'supervisor_user_id'];
+  if ($have(['student_id','supervisor_id']))           return ['student'=>'student_id','reviewer'=>'supervisor_id'];
+  return ['student'=>'student_user_id','reviewer'=>'supervisor_user_id'];
+}
+$sa = sa_cols($pdo);
+
+/* filters */
+$q=trim($_GET['q']??''); $from=trim($_GET['from']??''); $to=trim($_GET['to']??''); $status=trim($_GET['status']??'');
+$where=["sa.`{$sa['reviewer']}`=?"]; $args=[$me];
+if($q!==''){ $where[]="(u.name LIKE ? OR u.email LIKE ?)"; $args[]="%$q%"; $args[]="%$q%"; }
+if($from!==''){ $where[]="l.date_from >= ?"; $args[]=$from; }
+if($to!==''){ $where[]="l.date_to   <= ?"; $args[]=$to; }
+if($status!==''){ $where[]="l.status = ?"; $args[]=$status; }
+$sqlWhere='WHERE '.implode(' AND ',$where);
+$statuses=['pending','approved','rejected'];
+
+$sql="
+  SELECT l.id,l.user_id,l.date_from,l.date_to,l.reason,l.status,u.name,u.email
+  FROM leaves l
+  JOIN users u ON u.id=l.user_id
+  JOIN student_assignments sa ON sa.`{$sa['student']}`=u.id
+  $sqlWhere
+  ORDER BY l.date_from DESC,l.id DESC
+  LIMIT 200";
+$st=$pdo->prepare($sql); $st->execute($args); $rows=$st->fetchAll(PDO::FETCH_ASSOC);
+
+$title='Supervisor · Leaves';
+?>
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title><?= h($title) ?></title>
+<link rel="stylesheet" href="<?= $APP_BASE ?>/assets/style.css">
+</head><body>
+<?php include __DIR__.'/../app/header.php'; ?>
+<div class="container">
+  <h1>My Students · Leaves</h1>
+  <form method="get" class="filters" style="display:flex;gap:.5rem;flex-wrap:wrap;margin:.75rem 0 1rem">
+    <input name="q" value="<?= h($q) ?>" placeholder="Search student">
+    <input type="date" name="from" value="<?= h($from) ?>">
+    <input type="date" name="to" value="<?= h($to) ?>">
+    <select name="status">
+      <option value="">Any status</option>
+      <?php foreach($statuses as $s): ?><option value="<?= $s ?>" <?= $status===$s?'selected':'' ?>><?= ucfirst($s) ?></option><?php endforeach; ?>
+    </select>
+    <button class="btn">Filter</button>
+  </form>
+  <<table class="table">
+  <thead>
+    <tr><th>Dates</th><th>Student</th><th>Reason</th><th>Status</th><th>Actions</th></tr>
+  </thead>
+  <tbody>
+    <?php foreach($rows as $r): ?>
+      <tr>
+        <td><?= h($r['date_from']) ?> → <?= h($r['date_to']) ?></td>
+        <td><?= h($r['name']) ?> <small>(<?= h($r['email']) ?>)</small></td>
+        <td><?= h(mb_strimwidth((string)$r['reason'], 0, 120, '…')) ?></td>
+        <td><span class="status <?= h(strtolower($r['status'])) ?>"><?= h($r['status']) ?></span></td>
+
+        <td>
+          <a class="btn small" href="<?= $APP_BASE ?>/supervisor/verify_leaves.php?id=<?= (int)$r['id'] ?>">View / Verify</a>
+        </td>
+      </tr>
+    <?php endforeach; if(!$rows): ?>
+      <tr><td colspan="5">No results.</td></tr>
+    <?php endif; ?>
+  </tbody>
+</table>
+
+</div>
+</body></html>

--- a/INTERNS/supervisor/verify_daily.php
+++ b/INTERNS/supervisor/verify_daily.php
@@ -1,0 +1,114 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__.'/../app/auth.php';  require_role(['supervisor']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+function table_exists(PDO $pdo, string $t): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name=? LIMIT 1");
+  $st->execute([$t]); return (bool)$st->fetchColumn();
+}
+function col_exists(PDO $pdo,string $t,string $c): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name=? AND column_name=? LIMIT 1");
+  $st->execute([$t,$c]); return (bool)$st->fetchColumn();
+}
+
+$dailyTbl = table_exists($pdo,'daily_logs') ? 'daily_logs' : (table_exists($pdo,'logs') ? 'logs' : 'daily_logs');
+$imgTbl   = table_exists($pdo,'daily_images') ? 'daily_images' : (table_exists($pdo,'log_images') ? 'log_images' : 'daily_images');
+$dateCol  = col_exists($pdo,$dailyTbl,'log_date') ? 'log_date' : (col_exists($pdo,$dailyTbl,'date') ? 'date' : 'created_at');
+$uid=(int)$_SESSION['user']['id'];
+
+// handle sign/comment
+if($_SERVER['REQUEST_METHOD']==='POST'){
+  $id=(int)($_POST['id']??0);
+  $cmt=trim($_POST['comment']??'');
+  $now=date('Y-m-d H:i:s');
+  $sigPath=null;
+
+  if(!empty($_FILES['signature']['name'])){
+    $dir=__DIR__.'/../uploads/signatures'; if(!is_dir($dir)) @mkdir($dir,0775,true);
+    if($_FILES['signature']['error']===UPLOAD_ERR_OK){
+      $tmp=$_FILES['signature']['tmp_name']; $fi=new finfo(FILEINFO_MIME_TYPE); $mime=$fi->file($tmp);
+      if(strpos($mime,'image/')===0 && filesize($tmp)<=5*1024*1024){
+        $ext=strtolower(pathinfo($_FILES['signature']['name'],PATHINFO_EXTENSION));
+        $name=sprintf('sig_d_%d_%s.%s',$uid,date('YmdHis'),$ext);
+        if(move_uploaded_file($tmp,$dir.'/'.$name)) $sigPath='/uploads/signatures/'.$name;
+      }
+    }
+  }
+
+  $set=[]; $vals=[];
+  if(col_exists($pdo,$dailyTbl,'reviewer_comment')) {$set[]='reviewer_comment=?'; $vals[]=$cmt;}
+  if(col_exists($pdo,$dailyTbl,'reviewer_id'))      {$set[]='reviewer_id=?';      $vals[]=$uid;}
+  if(col_exists($pdo,$dailyTbl,'supervisor_signed_at')) {$set[]='supervisor_signed_at=?'; $vals[]=$now;}
+  if($sigPath && col_exists($pdo,$dailyTbl,'supervisor_signature_path')) {$set[]='supervisor_signature_path=?'; $vals[]=$sigPath;}
+  if(col_exists($pdo,$dailyTbl,'status')) {$set[]='status=?'; $vals[]='approved';}
+
+  if($id && $set){ $vals[]=$id; $sql="UPDATE `$dailyTbl` SET ".implode(',',$set)." WHERE id=?"; $pdo->prepare($sql)->execute($vals); }
+}
+
+// listing
+$filter=$_GET['status']??'submitted'; $where=''; $bind=[];
+if(col_exists($pdo,$dailyTbl,'status') && in_array($filter,['submitted','approved','rejected','all'],true)){
+  if($filter!=='all'){ $where='WHERE d.status=?'; $bind[]=$filter; }
+}
+$st=$pdo->prepare("SELECT d.*,u.name FROM `$dailyTbl` d JOIN users u ON u.id=d.user_id $where ORDER BY d.`$dateCol` DESC, d.id DESC");
+$st->execute($bind); $rows=$st->fetchAll();
+
+$fk=col_exists($pdo,$imgTbl,'daily_id')?'daily_id':(col_exists($pdo,$imgTbl,'log_id')?'log_id':'daily_id');
+$si=$pdo->prepare("SELECT path FROM `$imgTbl` WHERE `$fk`=? ORDER BY id");
+
+include __DIR__.'/../app/header.php';
+?>
+<h2>Verify Daily Logs (Supervisor)</h2>
+
+<form method="get" style="margin:.5rem 0">
+  <label>Status
+    <select name="status" onchange="this.form.submit()">
+      <option value="submitted" <?= $filter==='submitted'?'selected':'' ?>>Pending</option>
+      <option value="approved"  <?= $filter==='approved'?'selected':'' ?>>Approved</option>
+      <option value="rejected"  <?= $filter==='rejected'?'selected':'' ?>>Rejected</option>
+      <option value="all"       <?= $filter==='all'?'selected':'' ?>>All</option>
+    </select>
+  </label>
+</form>
+
+<?php if(!$rows): ?>
+  <p>No daily logs found.</p>
+<?php else: ?>
+  <table class="tbl">
+    <tr>
+      <th>Student</th><th>Date</th><th>Task</th><th>Objective</th><th>Procedure</th><th>Images</th><th>Status</th><th>Supervisor</th>
+    </tr>
+    <?php foreach($rows as $r): $si->execute([$r['id']]); $imgs=$si->fetchAll(PDO::FETCH_COLUMN); ?>
+      <tr>
+        <td><?= h($r['name']) ?></td>
+        <td><?= h($r[$dateCol] ?? '') ?></td>
+        <td><?= isset($r['tugas'])?nl2br(h($r['tugas'])): (isset($r['activity'])?nl2br(h($r['activity'])):'—') ?></td>
+        <td><?= isset($r['objektif'])?nl2br(h($r['objektif'])):'—' ?></td>
+        <td style="max-width:360px"><?= isset($r['prosedur'])?nl2br(h($r['prosedur'])):'—' ?></td>
+        <td>
+          <?php if($imgs): foreach($imgs as $p): ?>
+            <a href="<?= url($p) ?>" target="_blank"><img src="<?= url($p) ?>" style="height:40px;object-fit:cover;margin-right:.2rem;border-radius:.2rem"></a>
+          <?php endforeach; else: ?>—<?php endif; ?>
+        </td>
+        <td><?= h($r['status'] ?? '') ?></td>
+        <td>
+          <?php if(($r['status'] ?? 'submitted')==='submitted'): ?>
+            <form method="post" enctype="multipart/form-data">
+              <input type="hidden" name="id" value="<?= (int)$r['id'] ?>">
+              <input name="comment" placeholder="Supervisor comment" style="min-width:220px">
+              <input type="file" name="signature" accept="image/*">
+              <button class="btn">Sign / Approve</button>
+            </form>
+          <?php else: ?>
+            <?php if(!empty($r['reviewer_comment'])): ?><div><strong>Comment:</strong> <?= nl2br(h($r['reviewer_comment'])) ?></div><?php endif; ?>
+            <?php if(!empty($r['supervisor_signed_at'])): ?><div><strong>Signed:</strong> <?= h($r['supervisor_signed_at']) ?></div><?php endif; ?>
+            <?php if(!empty($r['supervisor_signature_path'])): ?><img src="<?= url($r['supervisor_signature_path']) ?>" style="height:36px;margin-top:.25rem"><?php endif; ?>
+          <?php endif; ?>
+        </td>
+      </tr>
+    <?php endforeach; ?>
+  </table>
+<?php endif; ?>
+</main></body></html>

--- a/INTERNS/supervisor/verify_leaves.php
+++ b/INTERNS/supervisor/verify_leaves.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__.'/../app/auth.php';  require_role(['supervisor']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+function col_exists(PDO $pdo, string $t, string $c): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name=? AND column_name=? LIMIT 1");
+  $st->execute([$t,$c]); return (bool)$st->fetchColumn();
+}
+$tbl='leaves'; $uid=(int)$_SESSION['user']['id'];
+$dateCol = col_exists($pdo,$tbl,'leave_date') ? 'leave_date' : (col_exists($pdo,$tbl,'date') ? 'date' : 'created_at');
+$daysCol = col_exists($pdo,$tbl,'days') ? 'days' : (col_exists($pdo,$tbl,'num_days') ? 'num_days' : (col_exists($pdo,$tbl,'no_of_days') ? 'no_of_days' : null));
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+  $id=(int)($_POST['id']??0);
+  $act=$_POST['action'] ?? '';
+  $cmt=trim($_POST['supervisor_comment'] ?? '');
+  $now=date('Y-m-d H:i:s');
+  $sigPath=null;
+
+  if(!empty($_FILES['signature']['name'])){
+    $dir=__DIR__.'/../uploads/signatures'; if(!is_dir($dir)) @mkdir($dir,0775,true);
+    if($_FILES['signature']['error']===UPLOAD_ERR_OK){
+      $tmp=$_FILES['signature']['tmp_name']; $fi=new finfo(FILEINFO_MIME_TYPE); $mime=$fi->file($tmp);
+      if(strpos($mime,'image/')===0 && filesize($tmp)<=5*1024*1024){
+        $ext=strtolower(pathinfo($_FILES['signature']['name'],PATHINFO_EXTENSION));
+        $name=sprintf('sig_l_%d_%s.%s',$uid,date('YmdHis'),$ext);
+        if(move_uploaded_file($tmp,$dir.'/'.$name)) $sigPath='/uploads/signatures/'.$name;
+      }
+    }
+  }
+
+  $set=[]; $vals=[];
+  if(col_exists($pdo,$tbl,'supervisor_comment'))   {$set[]='supervisor_comment=?';   $vals[]=$cmt;}
+  if(col_exists($pdo,$tbl,'supervisor_id'))        {$set[]='supervisor_id=?';        $vals[]=$uid;}
+  if(col_exists($pdo,$tbl,'supervisor_signed_at') && $act==='approve') {$set[]='supervisor_signed_at=?'; $vals[]=$now;}
+  if($sigPath && col_exists($pdo,$tbl,'supervisor_signature_path')) {$set[]='supervisor_signature_path=?'; $vals[]=$sigPath;}
+  if(col_exists($pdo,$tbl,'status')){
+    $set[]='status=?'; $vals[] = ($act==='reject') ? 'rejected' : 'approved';
+  }
+
+  if($id && $set){
+    $vals[]=$id; $sql="UPDATE `$tbl` SET ".implode(',',$set)." WHERE id=?";
+    $pdo->prepare($sql)->execute($vals);
+  }
+}
+
+$filter=$_GET['status']??'pending';
+$where=''; $bind=[];
+if(col_exists($pdo,$tbl,'status') && in_array($filter,['pending','approved','rejected','all'],true)){
+  if($filter!=='all'){ $where='WHERE l.status=?'; $bind[]=$filter; }
+}
+$st=$pdo->prepare("SELECT l.*, u.name FROM `$tbl` l JOIN users u ON u.id=l.user_id $where ORDER BY l.`$dateCol` DESC, l.id DESC");
+$st->execute($bind); $rows=$st->fetchAll();
+
+include __DIR__.'/../app/header.php';
+?>
+<h2>Verify Leave Requests (Supervisor)</h2>
+
+<form method="get" style="margin:.5rem 0">
+  <label>Status
+    <select name="status" onchange="this.form.submit()">
+      <option value="pending"  <?= $filter==='pending'?'selected':'' ?>>Pending</option>
+      <option value="approved" <?= $filter==='approved'?'selected':'' ?>>Approved</option>
+      <option value="rejected" <?= $filter==='rejected'?'selected':'' ?>>Rejected</option>
+      <option value="all"      <?= $filter==='all'?'selected':'' ?>>All</option>
+    </select>
+  </label>
+</form>
+
+<?php if(!$rows): ?><p>No leave requests found.</p>
+<?php else: ?>
+<table class="tbl">
+  <tr>
+    <th>Student</th>
+    <th>Date</th>
+    <?php if($daysCol): ?><th>No. of days</th><?php endif; ?>
+    <th>Reason</th>
+    <th>Status</th>
+    <th>Supervisor section</th>
+    <th>PDF</th>
+  </tr>
+  <?php foreach($rows as $r): ?>
+    <tr>
+      <td><?= h($r['name']) ?></td>
+      <td><?= h($r[$dateCol] ?? '') ?></td>
+      <?php if($daysCol): ?><td><?= h($r[$daysCol] ?? '') ?></td><?php endif; ?>
+      <td style="max-width:360px"><?= nl2br(h($r['reason'] ?? '')) ?></td>
+      <td><?= h($r['status'] ?? '') ?></td>
+      <td>
+        <?php if(($r['status'] ?? 'pending')==='pending'): ?>
+          <form method="post" enctype="multipart/form-data">
+            <input type="hidden" name="id" value="<?= (int)$r['id'] ?>">
+            <input name="supervisor_comment" placeholder="Comment" style="min-width:220px">
+            <input type="file" name="signature" accept="image/*">
+            <button class="btn" name="action" value="approve">Sign / Approve</button>
+            <button class="btn" name="action" value="reject">Reject</button>
+          </form>
+        <?php else: ?>
+          <?php if(!empty($r['supervisor_comment'])): ?><div><strong>Comment:</strong> <?= nl2br(h($r['supervisor_comment'])) ?></div><?php endif; ?>
+          <?php if(!empty($r['supervisor_signed_at'])): ?><div><strong>Signed:</strong> <?= h($r['supervisor_signed_at']) ?></div><?php endif; ?>
+          <?php if(!empty($r['supervisor_signature_path'])): ?><img src="<?= url($r['supervisor_signature_path']) ?>" style="height:36px;margin-top:.25rem"><?php endif; ?>
+        <?php endif; ?>
+      </td>
+      <td><a class="btn" target="_blank" href="<?= url('/student/leave_pdf.php?id='.(int)$r['id']) ?>">PDF</a></td>
+    </tr>
+  <?php endforeach; ?>
+</table>
+<?php endif; ?>
+</main></body></html>

--- a/INTERNS/supervisor/verify_weekly.php
+++ b/INTERNS/supervisor/verify_weekly.php
@@ -1,0 +1,145 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors','1'); ini_set('display_startup_errors','1'); error_reporting(E_ALL);
+
+require_once __DIR__.'/../app/auth.php';  require_role(['supervisor']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+function table_exists(PDO $pdo, string $t): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name=? LIMIT 1");
+  $st->execute([$t]); return (bool)$st->fetchColumn();
+}
+function col_exists(PDO $pdo, string $t, string $c): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name=? AND column_name=? LIMIT 1");
+  $st->execute([$t,$c]); return (bool)$st->fetchColumn();
+}
+
+$tbl    = table_exists($pdo,'weekly_reports') ? 'weekly_reports' : 'weekly_reports'; // required
+$imgTbl = table_exists($pdo,'weekly_images')  ? 'weekly_images'  : null;             // optional
+$uid    = (int)($_SESSION['user']['id'] ?? 0);
+
+// pick best date/week columns available
+$dateCol = col_exists($pdo,$tbl,'report_date') ? 'report_date' : (col_exists($pdo,$tbl,'date') ? 'date' : 'created_at');
+$weekCol = col_exists($pdo,$tbl,'week_no') ? 'week_no' : (col_exists($pdo,$tbl,'week') ? 'week' : null);
+
+// Handle supervisor sign/comment
+if($_SERVER['REQUEST_METHOD']==='POST'){
+  $id  = (int)($_POST['id'] ?? 0);
+  $cmt = trim($_POST['supervisor_comment'] ?? '');
+  $now = date('Y-m-d H:i:s');
+  $sigPath = null;
+
+  // signature upload (optional)
+  if(!empty($_FILES['signature']['name'])){
+    $dir = __DIR__.'/../uploads/signatures';
+    if(!is_dir($dir)) @mkdir($dir,0775,true);
+    if($_FILES['signature']['error']===UPLOAD_ERR_OK){
+      $tmp = $_FILES['signature']['tmp_name'];
+      $mime = (new finfo(FILEINFO_MIME_TYPE))->file($tmp);
+      if(strpos($mime,'image/')===0 && filesize($tmp) <= 5*1024*1024){
+        $ext = strtolower(pathinfo($_FILES['signature']['name'], PATHINFO_EXTENSION));
+        $name = sprintf('sig_w_%d_%s.%s',$uid,date('YmdHis'),$ext);
+        if(move_uploaded_file($tmp,$dir.'/'.$name)) $sigPath = '/uploads/signatures/'.$name;
+      }
+    }
+  }
+
+  // Only supervisor columns get updated
+  $set=[]; $vals=[];
+  if(col_exists($pdo,$tbl,'supervisor_comment'))   { $set[]='supervisor_comment=?';   $vals[]=$cmt; }
+  if(col_exists($pdo,$tbl,'supervisor_id'))        { $set[]='supervisor_id=?';        $vals[]=$uid; }
+  if(col_exists($pdo,$tbl,'supervisor_signed_at')) { $set[]='supervisor_signed_at=?'; $vals[]=$now; }
+  if($sigPath && col_exists($pdo,$tbl,'supervisor_signature_path')) { $set[]='supervisor_signature_path=?'; $vals[]=$sigPath; }
+  if(col_exists($pdo,$tbl,'status'))               { $set[]='status=?';               $vals[]='approved'; }
+
+  if($id && $set){
+    $vals[]=$id;
+    $sql="UPDATE `$tbl` SET ".implode(',',$set)." WHERE id=?";
+    $pdo->prepare($sql)->execute($vals);
+  }
+}
+
+// List reports
+$filter = $_GET['status'] ?? 'submitted';
+$where  = ''; $bind=[];
+if(col_exists($pdo,$tbl,'status') && in_array($filter,['submitted','approved','rejected','all'],true)){
+  if($filter!=='all'){ $where = "WHERE status=?"; $bind[]=$filter; }
+}
+$st = $pdo->prepare("SELECT * FROM `$tbl` $where ORDER BY `$dateCol` DESC, id DESC");
+$st->execute($bind); $rows = $st->fetchAll();
+
+$si = null; $fk = null;
+if ($imgTbl){
+  $fk = col_exists($pdo,$imgTbl,'weekly_id') ? 'weekly_id' : 'weekly_id';
+  $si = $pdo->prepare("SELECT path FROM `$imgTbl` WHERE `$fk`=? ORDER BY id");
+}
+
+include __DIR__.'/../app/header.php';
+?>
+<h2>Verify Weekly Reflections (Supervisor)</h2>
+
+<form method="get" style="margin:.5rem 0">
+  <label>Status
+    <select name="status" onchange="this.form.submit()">
+      <option value="submitted" <?= $filter==='submitted'?'selected':'' ?>>Pending</option>
+      <option value="approved"  <?= $filter==='approved'?'selected':'' ?>>Signed/approved</option>
+      <option value="rejected"  <?= $filter==='rejected'?'selected':'' ?>>Rejected</option>
+      <option value="all"       <?= $filter==='all'?'selected':'' ?>>All</option>
+    </select>
+  </label>
+</form>
+
+<?php if(!$rows): ?>
+  <p>No weekly reports found.</p>
+<?php else: ?>
+  <table class="tbl">
+    <tr>
+      <th>Date</th>
+      <?php if($weekCol): ?><th>Week</th><?php endif; ?>
+      <?php if(col_exists($pdo,$tbl,'activity_summary')): ?><th>Activity</th><?php endif; ?>
+      <?php if(col_exists($pdo,$tbl,'skills_gained')): ?><th>Skills</th><?php endif; ?>
+      <?php if(col_exists($pdo,$tbl,'impact_on_student')): ?><th>Impact</th><?php endif; ?>
+      <th>Images</th>
+      <?php if(col_exists($pdo,$tbl,'status')): ?><th>Status</th><?php endif; ?>
+      <th>Supervisor</th>
+      <th>PDF</th>
+    </tr>
+    <?php foreach($rows as $r): ?>
+      <?php
+        $imgs=[];
+        if($si){ $si->execute([$r['id']]); $imgs = $si->fetchAll(PDO::FETCH_COLUMN); }
+      ?>
+      <tr>
+        <td><?= h($r[$dateCol] ?? '') ?></td>
+        <?php if($weekCol): ?><td><?= h($r[$weekCol] ?? '') ?></td><?php endif; ?>
+        <td><?= isset($r['activity_summary'])?nl2br(h($r['activity_summary'])):'—' ?></td>
+        <td><?= isset($r['skills_gained'])?nl2br(h($r['skills_gained'])):'—' ?></td>
+        <td><?= isset($r['impact_on_student'])?nl2br(h($r['impact_on_student'])):'—' ?></td>
+        <td>
+          <?php if($imgs): foreach($imgs as $p): ?>
+            <a href="<?= url($p) ?>" target="_blank"><img src="<?= url($p) ?>" style="height:40px;object-fit:cover;margin-right:.2rem;border-radius:.2rem"></a>
+          <?php endforeach; else: ?>—<?php endif; ?>
+        </td>
+        <td><?= h($r['status'] ?? '') ?></td>
+        <td>
+          <?php if(($r['status'] ?? 'submitted')==='submitted'): ?>
+            <form method="post" enctype="multipart/form-data">
+              <input type="hidden" name="id" value="<?= (int)$r['id'] ?>">
+              <input name="supervisor_comment" placeholder="Comment / suggestion" style="min-width:220px">
+              <input type="file" name="signature" accept="image/*">
+              <button class="btn">Sign / Approve</button>
+            </form>
+          <?php else: ?>
+            <?php if(!empty($r['supervisor_comment'])): ?><div><strong>Comment:</strong> <?= nl2br(h($r['supervisor_comment'])) ?></div><?php endif; ?>
+            <?php if(!empty($r['supervisor_signed_at'])): ?><div><strong>Signed:</strong> <?= h($r['supervisor_signed_at']) ?></div><?php endif; ?>
+            <?php if(!empty($r['supervisor_signature_path'])): ?><img src="<?= url($r['supervisor_signature_path']) ?>" style="height:36px;margin-top:.25rem"><?php endif; ?>
+          <?php endif; ?>
+        </td>
+        <td><a class="btn" target="_blank" href="<?= url('/student/weekly_pdf.php?id='.(int)$r['id']) ?>">PDF</a></td>
+      </tr>
+    <?php endforeach; ?>
+  </table>
+<?php endif; ?>
+
+</main></body></html>

--- a/INTERNS/supervisor/weekly_list.php
+++ b/INTERNS/supervisor/weekly_list.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors','1'); ini_set('display_startup_errors','1'); error_reporting(E_ALL);
+
+require_once __DIR__ . '/../app/config.php';
+$config = (isset($config) && is_array($config)) ? $config : (is_array(@require __DIR__ . '/../app/config.php') ? require __DIR__ . '/../app/config.php' : []);
+require_once __DIR__ . '/../app/db.php';
+require_once __DIR__ . '/../app/session.php';
+require_once __DIR__ . '/../app/helpers.php';
+require_role(['supervisor']);
+
+$me = (int)($_SESSION['user']['id'] ?? 0);
+function app_base(?array $cfg): string { return rtrim(defined('APP_BASE') ? (string)APP_BASE : (string)($cfg['APP_BASE']??''), '/'); }
+$APP_BASE = app_base($config);
+
+function sa_cols(PDO $pdo): array {
+  $have=function(array $c) use($pdo){$in=implode(',',array_fill(0,count($c),'?'));$st=$pdo->prepare("SELECT COUNT(*) FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name='student_assignments' AND column_name IN ($in)");$st->execute($c);return (int)$st->fetchColumn()===count($c);};
+  if ($have(['student_user_id','supervisor_user_id'])) return ['student'=>'student_user_id','reviewer'=>'supervisor_user_id'];
+  if ($have(['student_id','supervisor_id']))           return ['student'=>'student_id','reviewer'=>'supervisor_id'];
+  return ['student'=>'student_user_id','reviewer'=>'supervisor_user_id'];
+}
+$sa = sa_cols($pdo);
+
+$q=trim($_GET['q']??''); $from=trim($_GET['from']??''); $to=trim($_GET['to']??'');
+$dateExpr="COALESCE(w.week_start,w.report_date,w.created_at)";
+$where=["sa.`{$sa['reviewer']}`=?"]; $args=[$me];
+if($q!==''){ $where[]="(u.name LIKE ? OR u.email LIKE ?)"; $args[]="%$q%"; $args[]="%$q%"; }
+if($from!==''){ $where[]="$dateExpr >= ?"; $args[]=$from; }
+if($to!==''){ $where[]="$dateExpr <= ?"; $args[]=$to; }
+$sqlWhere='WHERE '.implode(' AND ',$where);
+
+$sql="
+  SELECT
+    w.id,w.user_id,w.week_no,w.week_start,w.report_date,w.created_at,w.status,
+    COALESCE(w.activities_summary,w.activity_summary,w.highlights,'') AS summary,
+    COALESCE(w.week_start,w.report_date,w.created_at) AS week_val,
+    u.name,u.email
+  FROM weekly_reports w
+  JOIN users u ON u.id=w.user_id
+  JOIN student_assignments sa ON sa.`{$sa['student']}`=u.id
+  $sqlWhere
+  ORDER BY $dateExpr DESC, w.id DESC
+  LIMIT 200";
+$st=$pdo->prepare($sql); $st->execute($args); $rows=$st->fetchAll(PDO::FETCH_ASSOC);
+
+$title='Supervisor · Weekly Reports';
+?>
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title><?= h($title) ?></title>
+<link rel="stylesheet" href="<?= $APP_BASE ?>/assets/style.css">
+</head><body>
+<?php include __DIR__.'/../app/header.php'; ?>
+<div class="container">
+  <h1>My Students · Weekly Reports</h1>
+  <form method="get" class="filters" style="display:flex;gap:.5rem;flex-wrap:wrap;margin:.75rem 0 1rem">
+    <input name="q" value="<?= h($q) ?>" placeholder="Search student">
+    <input type="date" name="from" value="<?= h($from) ?>">
+    <input type="date" name="to" value="<?= h($to) ?>">
+    <button class="btn">Filter</button>
+  </form>
+  <table class="table">
+  <thead>
+    <tr><th>Week</th><th>Student</th><th>Summary</th><th>Status</th><th>Actions</th></tr>
+  </thead>
+  <tbody>
+    <?php foreach($rows as $r): ?>
+      <tr>
+        <td>
+          <?= h($r['week_val']) ?>
+          <?php if (!empty($r['week_no'])): ?>
+            <small>(Week <?= (int)$r['week_no'] ?>)</small>
+          <?php endif; ?>
+        </td>
+        <td><?= h($r['name']) ?> <small>(<?= h($r['email']) ?>)</small></td>
+        <td><?= h(mb_strimwidth((string)$r['summary'], 0, 120, '…')) ?></td>
+        <td><span class="status <?= h(strtolower($r['status'])) ?>"><?= h($r['status']) ?></span></td>
+
+        <td>
+          <a class="btn small" href="<?= $APP_BASE ?>/supervisor/verify_weekly.php?id=<?= (int)$r['id'] ?>">View / Verify</a>
+        </td>
+      </tr>
+    <?php endforeach; if(!$rows): ?>
+      <tr><td colspan="5">No results.</td></tr>
+    <?php endif; ?>
+  </tbody>
+</table>
+
+</div>
+</body></html>

--- a/INTERNS/tests/admin_routes.test.php
+++ b/INTERNS/tests/admin_routes.test.php
@@ -1,0 +1,42 @@
+<?php
+$root = realpath(__DIR__ . '/..');
+if ($root === false) {
+    fwrite(STDERR, "Unable to locate project root.\n");
+    exit(1);
+}
+
+$checks = [
+    'admin/daily_list.php'  => ['admin/verify_daily.php'],
+    'admin/weekly_list.php' => ['admin/verify_weekly.php'],
+    'admin/leaves_list.php' => ['admin/verify_leaves.php'],
+];
+
+$missing = [];
+foreach ($checks as $list => $targets) {
+    $listPath = $root . '/' . $list;
+    if (!is_file($listPath)) {
+        $missing[] = "Missing page: {$list}";
+        continue;
+    }
+
+    $content = file_get_contents($listPath) ?: '';
+    foreach ($targets as $target) {
+        $filePath = $root . '/' . $target;
+        if (!is_file($filePath)) {
+            $missing[] = "Missing verify page: {$target}";
+            continue;
+        }
+        if (strpos($content, basename($target)) === false) {
+            $missing[] = "List {$list} does not link to {$target}";
+        }
+    }
+}
+
+if ($missing) {
+    foreach ($missing as $msg) {
+        echo $msg, "\n";
+    }
+    exit(1);
+}
+
+echo "Admin verification routes are present.\n";


### PR DESCRIPTION
## Summary
- add dedicated admin verification pages for daily logs, weekly reports, and leave requests that reuse shared layout and status handling
- expose "View / Verify" actions on admin list screens to reach the new review workflows
- add a lightweight navigation test that checks each list links to its verification page

## Testing
- php -l INTERNS/admin/verify_daily.php
- php -l INTERNS/admin/verify_weekly.php
- php -l INTERNS/admin/verify_leaves.php
- php INTERNS/tests/admin_routes.test.php


------
https://chatgpt.com/codex/tasks/task_e_68ceb5b6ee84832fb0356f72f27c8a53