### PR TITLE
Improve weekly report workflows

### DIFF
--- a/INTERNS/lecturer/verify_weekly.php
+++ b/INTERNS/lecturer/verify_weekly.php
@@ -1,0 +1,271 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors','1'); ini_set('display_startup_errors','1'); error_reporting(E_ALL);
+
+require_once __DIR__.'/../app/auth.php';  require_role(['lecturer']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+function table_exists(PDO $pdo, string $t): bool {
+  $st = $pdo->prepare("SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ? LIMIT 1");
+  $st->execute([$t]);
+  return (bool)$st->fetchColumn();
+}
+function col_exists(PDO $pdo, string $t, string $c): bool {
+  $st = $pdo->prepare("SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ? LIMIT 1");
+  $st->execute([$t, $c]);
+  return (bool)$st->fetchColumn();
+}
+function assignment_columns(PDO $pdo): array {
+  $check = function(array $cols) use ($pdo): bool {
+    $in  = implode(',', array_fill(0, count($cols), '?'));
+    $sql = "SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'student_assignments' AND column_name IN ($in)";
+    $st  = $pdo->prepare($sql);
+    $st->execute($cols);
+    return (int)$st->fetchColumn() === count($cols);
+  };
+  if ($check(['student_user_id','lecturer_user_id'])) {
+    return ['student' => 'student_user_id', 'reviewer' => 'lecturer_user_id'];
+  }
+  if ($check(['student_id','lecturer_id'])) {
+    return ['student' => 'student_id', 'reviewer' => 'lecturer_id'];
+  }
+  return ['student' => 'student_user_id', 'reviewer' => 'lecturer_user_id'];
+}
+
+$tbl      = 'weekly_reports';
+$hasTable = table_exists($pdo, $tbl);
+$me       = (int)($_SESSION['user']['id'] ?? 0);
+$msg = '';
+$err = '';
+
+$assignmentJoin = '';
+$assignmentCond = '';
+if (table_exists($pdo, 'student_assignments')) {
+  $cols = assignment_columns($pdo);
+  $assignmentJoin = "JOIN student_assignments sa ON sa.`{$cols['student']}` = w.user_id";
+  $assignmentCond = "sa.`{$cols['reviewer']}` = ?";
+}
+
+$imgStmt = null;
+$imgFk   = null;
+if (table_exists($pdo, 'weekly_images')) {
+  foreach (['weekly_id','weekly_report_id'] as $cand) {
+    if (col_exists($pdo, 'weekly_images', $cand)) { $imgFk = $cand; break; }
+  }
+  if ($imgFk && col_exists($pdo, 'weekly_images', 'path')) {
+    $imgStmt = $pdo->prepare("SELECT path FROM `weekly_images` WHERE `$imgFk`=? ORDER BY id");
+  }
+}
+
+$dateExpr = "COALESCE(w.week_start, w.report_date, w.created_at)";
+$weekCol  = null;
+if (col_exists($pdo, $tbl, 'week_no'))      $weekCol = 'week_no';
+elseif (col_exists($pdo, $tbl, 'week'))     $weekCol = 'week';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (!$hasTable) {
+    $err = 'weekly_reports table not found.';
+  } else {
+    $id      = (int)($_POST['id'] ?? 0);
+    $action  = $_POST['action'] ?? '';
+    $comment = trim($_POST['comment'] ?? '');
+    if (!$id || !in_array($action, ['approved','rejected'], true)) {
+      $err = 'Invalid request.';
+    } else {
+      $checkSql = "SELECT w.id FROM `$tbl` w" . ($assignmentJoin ? " $assignmentJoin" : '') . " WHERE w.id = ?";
+      $args = [$id];
+      if ($assignmentCond) { $checkSql .= " AND $assignmentCond"; $args[] = $me; }
+      $chk = $pdo->prepare($checkSql);
+      $chk->execute($args);
+      if (!$chk->fetchColumn()) {
+        $err = 'Report not found or not assigned to you.';
+      } else {
+        $newStatus = ($action === 'approved') ? 'approved' : 'rejected';
+        $set = [];
+        $vals = [];
+        if (col_exists($pdo, $tbl, 'status'))            { $set[] = '`status`=?';            $vals[] = $newStatus; }
+        if (col_exists($pdo, $tbl, 'lecturer_comment'))  { $set[] = '`lecturer_comment`=?';  $vals[] = $comment; }
+        if (col_exists($pdo, $tbl, 'reviewer_comment'))  { $set[] = '`reviewer_comment`=?';  $vals[] = $comment; }
+        if (col_exists($pdo, $tbl, 'lecturer_id'))       { $set[] = '`lecturer_id`=?';       $vals[] = $me; }
+        elseif (col_exists($pdo, $tbl, 'reviewer_id'))   { $set[] = '`reviewer_id`=?';       $vals[] = $me; }
+        if (col_exists($pdo, $tbl, 'lecturer_signed_at')) {
+          if ($action === 'approved') { $set[] = '`lecturer_signed_at`=?'; $vals[] = date('Y-m-d H:i:s'); }
+          else { $set[] = '`lecturer_signed_at`=NULL'; }
+        }
+        if (col_exists($pdo, $tbl, 'updated_at')) { $set[] = '`updated_at`=NOW()'; }
+        if (!$set) {
+          $err = 'No writable columns available for weekly reports.';
+        } else {
+          $vals[] = $id;
+          $sql = "UPDATE `$tbl` SET " . implode(', ', $set) . " WHERE id=?";
+          $pdo->prepare($sql)->execute($vals);
+          $msg = $newStatus === 'approved' ? 'Weekly report approved.' : 'Weekly report rejected.';
+        }
+      }
+    }
+  }
+}
+
+$filter = $_GET['status'] ?? 'submitted';
+$allowedFilters = ['submitted','approved','rejected','signed','all'];
+if (!in_array($filter, $allowedFilters, true)) $filter = 'submitted';
+$q = trim($_GET['q'] ?? '');
+
+$rows = [];
+if ($hasTable) {
+  $where = [];
+  $args  = [];
+  if ($assignmentCond) { $where[] = $assignmentCond; $args[] = $me; }
+  if ($q !== '') { $where[] = "(u.name LIKE ? OR u.email LIKE ?)"; $args[] = "%$q%"; $args[] = "%$q%"; }
+  if ($filter !== 'all' && col_exists($pdo, $tbl, 'status')) { $where[] = "w.`status` = ?"; $args[] = $filter; }
+  $sqlWhere = $where ? ('WHERE ' . implode(' AND ', $where)) : '';
+  $sql = "
+    SELECT
+      w.*,
+      u.name,
+      u.email,
+      $dateExpr AS week_val,
+      COALESCE(w.activities_summary, w.activity_summary, w.highlights, '') AS summary_text
+    FROM `$tbl` w
+    JOIN users u ON u.id = w.user_id
+    " . ($assignmentJoin ? " $assignmentJoin" : '') . "
+    $sqlWhere
+    ORDER BY $dateExpr DESC, w.id DESC
+    LIMIT 200
+  ";
+  $st = $pdo->prepare($sql);
+  $st->execute($args);
+  $rows = $st->fetchAll(PDO::FETCH_ASSOC);
+}
+
+include __DIR__.'/../app/header.php';
+?>
+<h2>Verify Weekly Reports (Lecturer)</h2>
+
+<?php if($msg): ?><p class="ok"><?= h($msg) ?></p><?php endif; ?>
+<?php if($err): ?><p class="error"><?= h($err) ?></p><?php endif; ?>
+
+<form method="get" class="filters" style="display:flex;gap:.5rem;flex-wrap:wrap;margin:.75rem 0 1rem">
+  <input name="q" value="<?= h($q) ?>" placeholder="Search student">
+  <select name="status">
+    <?php foreach(['submitted'=>'Submitted','approved'=>'Approved','rejected'=>'Rejected','signed'=>'Signed','all'=>'All'] as $val=>$label): ?>
+      <option value="<?= h($val) ?>" <?= $filter===$val?'selected':'' ?>><?= h($label) ?></option>
+    <?php endforeach; ?>
+  </select>
+  <button class="btn">Filter</button>
+</form>
+
+<?php if(!$hasTable): ?>
+  <p>weekly_reports table not found.</p>
+<?php elseif(!$rows): ?>
+  <p>No weekly reports found.</p>
+<?php else: ?>
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Week</th>
+        <th>Student</th>
+        <th>Summary &amp; Comments</th>
+        <th>Images</th>
+        <th>Status</th>
+        <th>Lecturer Review</th>
+        <th>PDF</th>
+      </tr>
+    </thead>
+    <tbody>
+    <?php foreach($rows as $r): ?>
+      <?php
+        $weekStart = array_key_exists('week_start', $r) ? $r['week_start'] : null;
+        $weekEnd   = array_key_exists('week_end', $r)   ? $r['week_end']   : null;
+        $weekDisp  = '';
+        if ($weekStart || $weekEnd) {
+          $parts = [];
+          if ($weekStart) $parts[] = $weekStart;
+          if ($weekEnd)   $parts[] = $weekEnd;
+          $weekDisp = implode(' → ', $parts);
+        } else {
+          $weekDisp = $r['week_val'] ?? '';
+        }
+        $summary = trim((string)($r['summary_text'] ?? ''));
+        $supComment = trim((string)($r['supervisor_comment'] ?? ''));
+        $lecComment = trim((string)($r['lecturer_comment'] ?? ''));
+        $statusVal  = $r['status'] ?? '';
+        $imgs = [];
+        if ($imgStmt) {
+          $imgStmt->execute([$r['id']]);
+          $imgs = $imgStmt->fetchAll(PDO::FETCH_COLUMN);
+        }
+        $canReview = in_array($statusVal, ['submitted','rejected',''], true);
+      ?>
+      <tr>
+        <td>
+          <?= h($weekDisp) ?>
+          <?php if($weekCol && isset($r[$weekCol]) && $r[$weekCol] !== null && $r[$weekCol] !== ''): ?>
+            <div><small>Week <?= h((string)$r[$weekCol]) ?></small></div>
+          <?php endif; ?>
+        </td>
+        <td>
+          <strong><?= h($r['name'] ?? '') ?></strong><br>
+          <small><?= h($r['email'] ?? '') ?></small>
+        </td>
+        <td style="max-width:360px">
+          <?php if($summary !== ''): ?>
+            <div><?= nl2br(h($summary)) ?></div>
+          <?php else: ?>
+            <em>No summary provided.</em>
+          <?php endif; ?>
+          <?php if($supComment !== ''): ?>
+            <div style="margin-top:.35rem"><small><strong>Supervisor:</strong> <?= nl2br(h($supComment)) ?></small></div>
+          <?php endif; ?>
+          <?php if(!$canReview && $lecComment !== ''): ?>
+            <div style="margin-top:.35rem"><small><strong>Your comment:</strong> <?= nl2br(h($lecComment)) ?></small></div>
+          <?php endif; ?>
+        </td>
+        <td>
+          <?php if($imgs): ?>
+            <div style="display:flex;gap:.25rem;flex-wrap:wrap">
+              <?php foreach($imgs as $p): ?>
+                <a href="<?= url($p) ?>" target="_blank"><img src="<?= url($p) ?>" alt="" style="height:48px;width:72px;object-fit:cover;border-radius:.3rem"></a>
+              <?php endforeach; ?>
+            </div>
+          <?php else: ?>
+            <em>—</em>
+          <?php endif; ?>
+        </td>
+        <td>
+          <?php if($statusVal !== ''): ?>
+            <span class="status <?= h(strtolower($statusVal)) ?>"><?= h($statusVal) ?></span>
+          <?php else: ?>
+            <em>—</em>
+          <?php endif; ?>
+          <?php if(!empty($r['lecturer_signed_at'])): ?>
+            <div><small>Signed: <?= h($r['lecturer_signed_at']) ?></small></div>
+          <?php endif; ?>
+        </td>
+        <td>
+          <?php if($canReview): ?>
+            <form method="post" style="display:flex;flex-direction:column;gap:.35rem">
+              <input type="hidden" name="id" value="<?= (int)$r['id'] ?>">
+              <textarea name="comment" rows="2" placeholder="Comment" style="min-width:220px;resize:vertical"><?= h($lecComment) ?></textarea>
+              <div style="display:flex;gap:.35rem;flex-wrap:wrap">
+                <button class="btn small" name="action" value="approved">Approve</button>
+                <button class="btn small" name="action" value="rejected">Reject</button>
+              </div>
+            </form>
+          <?php else: ?>
+            <?php if($lecComment !== ''): ?>
+              <div><?= nl2br(h($lecComment)) ?></div>
+            <?php else: ?>
+              <em>No lecturer comment.</em>
+            <?php endif; ?>
+          <?php endif; ?>
+        </td>
+        <td><a class="btn small" target="_blank" href="<?= url('/student/weekly_pdf.php?id='.(int)$r['id']) ?>">PDF</a></td>
+      </tr>
+    <?php endforeach; ?>
+    </tbody>
+  </table>
+<?php endif; ?>
+
+</main></body></html>

--- a/INTERNS/student/weekly_new.php
+++ b/INTERNS/student/weekly_new.php
@@ -1,0 +1,123 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__.'/../app/auth.php';  require_role(['student']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+function col_exists(PDO $pdo, string $t, string $c): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name=? AND column_name=? LIMIT 1");
+  $st->execute([$t,$c]); return (bool)$st->fetchColumn();
+}
+function table_exists(PDO $pdo, string $t): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name=? LIMIT 1");
+  $st->execute([$t]); return (bool)$st->fetchColumn();
+}
+
+$tbl = 'weekly_reports';
+$imgTable = table_exists($pdo,'weekly_images') ? 'weekly_images' : 'weekly_images';
+$uid = (int)($_SESSION['user']['id'] ?? 0);
+
+$msg=''; $err='';
+if($_SERVER['REQUEST_METHOD']==='POST'){
+  $report_date = $_POST['report_date'] ?? '';
+  $week_no     = (int)($_POST['week_no'] ?? 0);
+  $activity    = trim($_POST['activity_summary'] ?? '');
+  $skills      = trim($_POST['skills_gained'] ?? '');
+  $impact      = trim($_POST['impact_on_student'] ?? '');
+
+  if(!$report_date || !$week_no || !$activity || !$skills || !$impact){
+    $err = 'Please fill in Date, Week, Activity Summary, Skills Gained and Impact.';
+  }
+
+  if(!$err){
+    try{
+      $base = [
+        'user_id'             => $uid,
+        'report_date'         => $report_date,
+        'week_no'             => $week_no,
+        'activity_summary'    => $activity,
+        'activities_summary'  => $activity,
+        'skills_gained'       => $skills,
+        'impact_on_student'   => $impact,
+        'status'              => 'submitted',
+      ];
+      // backward-compat mappings if your columns differ
+      if(col_exists($pdo,$tbl,'date'))     $base['date'] = $report_date;
+      if(col_exists($pdo,$tbl,'week'))     $base['week'] = $week_no;
+      if(col_exists($pdo,$tbl,'summary'))  $base['summary'] = $activity;
+      if(col_exists($pdo,$tbl,'knowledge'))$base['knowledge'] = $skills;
+      if(col_exists($pdo,$tbl,'impact'))   $base['impact'] = $impact;
+
+      $payload=[];
+      foreach($base as $k=>$v) if(col_exists($pdo,$tbl,$k)) $payload[$k]=$v;
+
+      foreach (['user_id','report_date'] as $must)
+        if(!col_exists($pdo,$tbl,$must)) throw new RuntimeException("Missing column `$must` in weekly_reports.");
+
+      $cols=implode(',',array_map(fn($c)=>"`$c`",array_keys($payload)));
+      $qst =implode(',',array_fill(0,count($payload),'?'));
+      $st=$pdo->prepare("INSERT INTO `$tbl` ($cols) VALUES ($qst)");
+      $st->execute(array_values($payload));
+      $wid=(int)$pdo->lastInsertId();
+
+      // images
+      if(!empty($_FILES['images']['name'][0])){
+        $dir = __DIR__.'/../uploads/weekly';
+        if(!is_dir($dir)) @mkdir($dir,0775,true);
+        $fk = col_exists($pdo,$imgTable,'weekly_id') ? 'weekly_id' : 'weekly_id';
+        $ist=$pdo->prepare("INSERT INTO `$imgTable` (`$fk`,`path`) VALUES (?,?)");
+
+        $files=$_FILES['images']; $fi = new finfo(FILEINFO_MIME_TYPE);
+        for($i=0;$i<count($files['name']);$i++){
+          if($files['error'][$i]!==UPLOAD_ERR_OK) continue;
+          $tmp=$files['tmp_name'][$i]; $mime=$fi->file($tmp);
+          if(strpos($mime,'image/')!==0) continue;
+          if(filesize($tmp)>5*1024*1024) continue;
+
+          $ext=strtolower(pathinfo($files['name'][$i],PATHINFO_EXTENSION));
+          $safe=preg_replace('/[^a-zA-Z0-9._-]/','_',pathinfo($files['name'][$i],PATHINFO_FILENAME));
+          $name=sprintf('w_%d_%s_%s.%s',$uid,date('YmdHis'),$safe,$ext);
+          $dest=$dir.'/'.$name;
+          if(move_uploaded_file($tmp,$dest)){
+            $ist->execute([$wid, '/uploads/weekly/'.$name]);
+          }
+        }
+      }
+
+      $msg='Weekly reflection submitted.';
+    }catch(Throwable $e){ $err='Save failed: '.$e->getMessage(); }
+  }
+}
+
+include __DIR__.'/../app/header.php';
+?>
+<h2>Weekly Reflection</h2>
+<?php if($msg):?><p class="ok"><?= h($msg) ?></p><?php endif; ?>
+<?php if($err):?><p class="error"><?= h($err) ?></p><?php endif; ?>
+
+<form method="post" enctype="multipart/form-data">
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
+    <label>Date <input type="date" name="report_date" required></label>
+    <label>Week <input type="number" name="week_no" min="1" step="1" required></label>
+  </div>
+  <fieldset style="margin-top:12px;border:1px solid var(--line);border-radius:.5rem">
+    <legend>To be completed by Student</legend>
+    <label>Weekly activities carried out (brief)
+      <textarea name="activity_summary" rows="6" required></textarea></label>
+    <label>Knowledge/skills acquired (during the week)
+      <textarea name="skills_gained" rows="6" required></textarea></label>
+    <label>Impact and effects on the student
+      <textarea name="impact_on_student" rows="6" required></textarea></label>
+  </fieldset>
+
+  <label style="margin-top:10px">Images (you may select multiple)
+    <input type="file" name="images[]" accept="image/*" multiple>
+  </label>
+
+  <p style="opacity:.8;margin:.5rem 0 1rem"><em>The section below is for the Industry Supervisor and is not editable here.</em></p>
+  <button class="btn">Submit</button>
+</form>
+
+<p><a href="<?= url('/student/weekly_list.php') ?>">My weekly reflections</a></p>
+<p><a href="<?= url('/student/dashboard.php') ?>">Back to dashboard</a></p>
+</main></body></html>

--- a/INTERNS/student/weekly_pdf.php
+++ b/INTERNS/student/weekly_pdf.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__.'/../app/auth.php';  require_role(['student']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+function col_exists(PDO $pdo, string $t, string $c): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name=? AND column_name=? LIMIT 1");
+  $st->execute([$t,$c]); return (bool)$st->fetchColumn();
+}
+
+$id  = (int)($_GET['id'] ?? 0);
+$uid = (int)($_SESSION['user']['id'] ?? 0);
+$tbl = 'weekly_reports';
+$imgTbl = 'weekly_images';
+
+$dateCol = col_exists($pdo,$tbl,'report_date') ? 'report_date' : (col_exists($pdo,$tbl,'date') ? 'date' : 'created_at');
+$weekCol = col_exists($pdo,$tbl,'week_no') ? 'week_no' : (col_exists($pdo,$tbl,'week') ? 'week' : null);
+
+$st=$pdo->prepare("SELECT * FROM `$tbl` WHERE id=? AND user_id=? LIMIT 1");
+$st->execute([$id,$uid]);
+$w=$st->fetch(); if(!$w){ http_response_code(404); echo 'Not found'; exit; }
+
+$fk = col_exists($pdo,$imgTbl,'weekly_id') ? 'weekly_id' : 'weekly_id';
+$si=$pdo->prepare("SELECT path FROM `$imgTbl` WHERE `$fk`=? ORDER BY id");
+$si->execute([$id]); $imgs=$si->fetchAll(PDO::FETCH_COLUMN);
+
+$base = rtrim((require __DIR__.'/../app/config.php')['APP_BASE'],'/');
+$activitySummary = $w['activity_summary'] ?? $w['activities_summary'] ?? null;
+
+ob_start(); ?>
+<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Weekly Reflection</title>
+<style>
+ body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial;margin:28px;font-size:13px;color:#111}
+ h1{font-size:20px;margin:0 0 8px} .label{font-weight:700;margin-top:8px}
+ .box{border:1px solid #bbb;border-radius:6px;padding:8px;min-height:44px}
+ .row{display:flex;gap:12px} .col{flex:1}
+ .imgs{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
+ .imgs img{height:120px;object-fit:cover;border:1px solid #bbb;border-radius:4px}
+ .badge{display:inline-block;padding:2px 8px;border-radius:999px;background:#eee;font-size:12px}
+ @media print{.noprint{display:none}}
+</style>
+</head>
+<body>
+  <div class="noprint" style="text-align:right;margin-bottom:6px">
+    <button onclick="window.print()">Print / Save as PDF</button>
+  </div>
+
+  <h1>Weekly Reflection</h1>
+  <div><?php if(isset($w['status'])): ?><span class="badge">Status: <?= htmlspecialchars($w['status']) ?></span><?php endif; ?></div>
+
+  <div class="row" style="margin-top:8px">
+    <div class="col"><div class="label">Date</div><div class="box"><?= htmlspecialchars($w[$dateCol] ?? '') ?></div></div>
+    <?php if($weekCol): ?><div class="col"><div class="label">Week</div><div class="box"><?= htmlspecialchars($w[$weekCol] ?? '') ?></div></div><?php endif; ?>
+  </div>
+
+  <?php if($activitySummary !== null && $activitySummary !== ''): ?><div class="label">Weekly activities carried out (brief)</div>
+  <div class="box"><?= nl2br(htmlspecialchars($activitySummary)) ?></div><?php endif; ?>
+
+  <?php if(isset($w['skills_gained'])): ?><div class="label">Knowledge/skills acquired (during the week)</div>
+  <div class="box"><?= nl2br(htmlspecialchars($w['skills_gained'])) ?></div><?php endif; ?>
+
+  <?php if(isset($w['impact_on_student'])): ?><div class="label">Impact and effects on the student</div>
+  <div class="box"><?= nl2br(htmlspecialchars($w['impact_on_student'])) ?></div><?php endif; ?>
+
+  <?php if($imgs): ?><div class="label">Images</div>
+    <div class="imgs">
+      <?php foreach($imgs as $p): ?><img src="<?= htmlspecialchars($base.$p) ?>" alt=""><?php endforeach; ?>
+    </div>
+  <?php endif; ?>
+
+  <?php if(!empty($w['supervisor_comment']) || !empty($w['supervisor_signature_path'])): ?>
+    <div class="label">Supervisor section</div>
+    <div class="box">
+      <?php if(!empty($w['supervisor_comment'])): ?>
+        <div><strong>Comment: </strong><?= nl2br(htmlspecialchars($w['supervisor_comment'])) ?></div>
+      <?php endif; ?>
+      <?php if(!empty($w['supervisor_signed_at'])): ?>
+        <div><strong>Signed at: </strong><?= htmlspecialchars($w['supervisor_signed_at']) ?></div>
+      <?php endif; ?>
+      <?php if(!empty($w['supervisor_signature_path'])): ?>
+        <div style="margin-top:6px"><img src="<?= htmlspecialchars($base.$w['supervisor_signature_path']) ?>" style="height:60px"></div>
+      <?php endif; ?>
+    </div>
+  <?php endif; ?>
+</body>
+</html>
+<?php
+$html = ob_get_clean();
+$autoload = __DIR__.'/../vendor/autoload.php';
+if(file_exists($autoload)){
+  require_once $autoload;
+  $opt=new Dompdf\Options(); $opt->set('isRemoteEnabled',true); $opt->set('isHtml5ParserEnabled',true);
+  $pdf=new Dompdf\Dompdf($opt); $pdf->loadHtml($html,'UTF-8'); $pdf->setPaper('A4','portrait'); $pdf->render();
+  $pdf->stream("weekly_$id.pdf",['Attachment'=>false]); exit;
+}
+echo $html;

--- a/INTERNS/supervisor/verify_weekly.php
+++ b/INTERNS/supervisor/verify_weekly.php
@@ -1,0 +1,146 @@
+<?php
+declare(strict_types=1);
+ini_set('display_errors','1'); ini_set('display_startup_errors','1'); error_reporting(E_ALL);
+
+require_once __DIR__.'/../app/auth.php';  require_role(['supervisor']);
+require_once __DIR__.'/../app/db.php';
+require_once __DIR__.'/../app/helpers.php';
+
+function table_exists(PDO $pdo, string $t): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name=? LIMIT 1");
+  $st->execute([$t]); return (bool)$st->fetchColumn();
+}
+function col_exists(PDO $pdo, string $t, string $c): bool {
+  $st=$pdo->prepare("SELECT 1 FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name=? AND column_name=? LIMIT 1");
+  $st->execute([$t,$c]); return (bool)$st->fetchColumn();
+}
+
+$tbl    = table_exists($pdo,'weekly_reports') ? 'weekly_reports' : 'weekly_reports'; // required
+$imgTbl = table_exists($pdo,'weekly_images')  ? 'weekly_images'  : null;             // optional
+$uid    = (int)($_SESSION['user']['id'] ?? 0);
+
+// pick best date/week columns available
+$dateCol = col_exists($pdo,$tbl,'report_date') ? 'report_date' : (col_exists($pdo,$tbl,'date') ? 'date' : 'created_at');
+$weekCol = col_exists($pdo,$tbl,'week_no') ? 'week_no' : (col_exists($pdo,$tbl,'week') ? 'week' : null);
+
+// Handle supervisor sign/comment
+if($_SERVER['REQUEST_METHOD']==='POST'){
+  $id  = (int)($_POST['id'] ?? 0);
+  $cmt = trim($_POST['supervisor_comment'] ?? '');
+  $now = date('Y-m-d H:i:s');
+  $sigPath = null;
+
+  // signature upload (optional)
+  if(!empty($_FILES['signature']['name'])){
+    $dir = __DIR__.'/../uploads/signatures';
+    if(!is_dir($dir)) @mkdir($dir,0775,true);
+    if($_FILES['signature']['error']===UPLOAD_ERR_OK){
+      $tmp = $_FILES['signature']['tmp_name'];
+      $mime = (new finfo(FILEINFO_MIME_TYPE))->file($tmp);
+      if(strpos($mime,'image/')===0 && filesize($tmp) <= 5*1024*1024){
+        $ext = strtolower(pathinfo($_FILES['signature']['name'], PATHINFO_EXTENSION));
+        $name = sprintf('sig_w_%d_%s.%s',$uid,date('YmdHis'),$ext);
+        if(move_uploaded_file($tmp,$dir.'/'.$name)) $sigPath = '/uploads/signatures/'.$name;
+      }
+    }
+  }
+
+  // Only supervisor columns get updated
+  $set=[]; $vals=[];
+  if(col_exists($pdo,$tbl,'supervisor_comment'))   { $set[]='supervisor_comment=?';   $vals[]=$cmt; }
+  if(col_exists($pdo,$tbl,'supervisor_id'))        { $set[]='supervisor_id=?';        $vals[]=$uid; }
+  if(col_exists($pdo,$tbl,'supervisor_signed_at')) { $set[]='supervisor_signed_at=?'; $vals[]=$now; }
+  if($sigPath && col_exists($pdo,$tbl,'supervisor_signature_path')) { $set[]='supervisor_signature_path=?'; $vals[]=$sigPath; }
+  if(col_exists($pdo,$tbl,'status'))               { $set[]='status=?';               $vals[]='approved'; }
+
+  if($id && $set){
+    $vals[]=$id;
+    $sql="UPDATE `$tbl` SET ".implode(',',$set)." WHERE id=?";
+    $pdo->prepare($sql)->execute($vals);
+  }
+}
+
+// List reports
+$filter = $_GET['status'] ?? 'submitted';
+$where  = ''; $bind=[];
+if(col_exists($pdo,$tbl,'status') && in_array($filter,['submitted','approved','rejected','all'],true)){
+  if($filter!=='all'){ $where = "WHERE status=?"; $bind[]=$filter; }
+}
+$st = $pdo->prepare("SELECT * FROM `$tbl` $where ORDER BY `$dateCol` DESC, id DESC");
+$st->execute($bind); $rows = $st->fetchAll();
+
+$si = null; $fk = null;
+if ($imgTbl){
+  $fk = col_exists($pdo,$imgTbl,'weekly_id') ? 'weekly_id' : 'weekly_id';
+  $si = $pdo->prepare("SELECT path FROM `$imgTbl` WHERE `$fk`=? ORDER BY id");
+}
+
+include __DIR__.'/../app/header.php';
+?>
+<h2>Verify Weekly Reflections (Supervisor)</h2>
+
+<form method="get" style="margin:.5rem 0">
+  <label>Status
+    <select name="status" onchange="this.form.submit()">
+      <option value="submitted" <?= $filter==='submitted'?'selected':'' ?>>Pending</option>
+      <option value="approved"  <?= $filter==='approved'?'selected':'' ?>>Signed/approved</option>
+      <option value="rejected"  <?= $filter==='rejected'?'selected':'' ?>>Rejected</option>
+      <option value="all"       <?= $filter==='all'?'selected':'' ?>>All</option>
+    </select>
+  </label>
+</form>
+
+<?php if(!$rows): ?>
+  <p>No weekly reports found.</p>
+<?php else: ?>
+  <table class="tbl">
+    <tr>
+      <th>Date</th>
+      <?php if($weekCol): ?><th>Week</th><?php endif; ?>
+      <?php if(col_exists($pdo,$tbl,'activity_summary')): ?><th>Activity</th><?php endif; ?>
+      <?php if(col_exists($pdo,$tbl,'skills_gained')): ?><th>Skills</th><?php endif; ?>
+      <?php if(col_exists($pdo,$tbl,'impact_on_student')): ?><th>Impact</th><?php endif; ?>
+      <th>Images</th>
+      <?php if(col_exists($pdo,$tbl,'status')): ?><th>Status</th><?php endif; ?>
+      <th>Supervisor</th>
+      <th>PDF</th>
+    </tr>
+    <?php foreach($rows as $r): ?>
+      <?php
+        $imgs=[];
+        if($si){ $si->execute([$r['id']]); $imgs = $si->fetchAll(PDO::FETCH_COLUMN); }
+      ?>
+      <tr>
+        <td><?= h($r[$dateCol] ?? '') ?></td>
+        <?php if($weekCol): ?><td><?= h($r[$weekCol] ?? '') ?></td><?php endif; ?>
+        <?php $summary = $r['activity_summary'] ?? $r['activities_summary'] ?? $r['highlights'] ?? ''; ?>
+        <td><?= $summary !== '' ? nl2br(h($summary)) : '—' ?></td>
+        <td><?= isset($r['skills_gained'])?nl2br(h($r['skills_gained'])):'—' ?></td>
+        <td><?= isset($r['impact_on_student'])?nl2br(h($r['impact_on_student'])):'—' ?></td>
+        <td>
+          <?php if($imgs): foreach($imgs as $p): ?>
+            <a href="<?= url($p) ?>" target="_blank"><img src="<?= url($p) ?>" style="height:40px;object-fit:cover;margin-right:.2rem;border-radius:.2rem"></a>
+          <?php endforeach; else: ?>—<?php endif; ?>
+        </td>
+        <td><?= h($r['status'] ?? '') ?></td>
+        <td>
+          <?php if(($r['status'] ?? 'submitted')==='submitted'): ?>
+            <form method="post" enctype="multipart/form-data">
+              <input type="hidden" name="id" value="<?= (int)$r['id'] ?>">
+              <input name="supervisor_comment" placeholder="Comment / suggestion" style="min-width:220px">
+              <input type="file" name="signature" accept="image/*">
+              <button class="btn">Sign / Approve</button>
+            </form>
+          <?php else: ?>
+            <?php if(!empty($r['supervisor_comment'])): ?><div><strong>Comment:</strong> <?= nl2br(h($r['supervisor_comment'])) ?></div><?php endif; ?>
+            <?php if(!empty($r['supervisor_signed_at'])): ?><div><strong>Signed:</strong> <?= h($r['supervisor_signed_at']) ?></div><?php endif; ?>
+            <?php if(!empty($r['supervisor_signature_path'])): ?><img src="<?= url($r['supervisor_signature_path']) ?>" style="height:36px;margin-top:.25rem"><?php endif; ?>
+          <?php endif; ?>
+        </td>
+        <td><a class="btn" target="_blank" href="<?= url('/student/weekly_pdf.php?id='.(int)$r['id']) ?>">PDF</a></td>
+      </tr>
+    <?php endforeach; ?>
+  </table>
+<?php endif; ?>
+
+</main></body></html>


### PR DESCRIPTION
## Summary
- add a fully schema-aware lecturer weekly verification page with filtering, commenting, and status updates
- make supervisor and PDF views resilient to weekly_reports columns by falling back to available summary fields
- ensure student weekly submissions populate the plural activities_summary column when present

## Testing
- php -l INTERNS/student/weekly_new.php
- php -l INTERNS/student/weekly_pdf.php
- php -l INTERNS/supervisor/verify_weekly.php
- php -l INTERNS/lecturer/verify_weekly.php

------
https://chatgpt.com/codex/tasks/task_e_68ced46fd6e0832f91b2c0224965f66f